### PR TITLE
Configurable Kubernetes version in module

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ variable "agents_count" {
   default     = 2
 }
 
+variable "kubernetes_version" {
+  description = "Version of Kubernetes to install"
+  default     = "1.11.3"
+}
+
 variable "public_ssh_key" {
   description = "A custom ssh key to control access to the AKS cluster"
   default = ""

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,7 @@ module "kubernetes" {
   admin_public_ssh_key            = "${var.public_ssh_key == "" ? module.ssh-key.public_ssh_key : var.public_ssh_key }"
   agents_size                     = "${var.agents_size}"
   agents_count                    = "${var.agents_count}"
+  kubernetes_version              = "${var.kubernetes_version}"
   service_principal_client_id     = "${var.CLIENT_ID}"
   service_principal_client_secret = "${var.CLIENT_SECRET}"
   log_analytics_workspace_id      = "${module.log_analytics_workspace.id}"

--- a/modules/kubernetes-cluster/main.tf
+++ b/modules/kubernetes-cluster/main.tf
@@ -3,7 +3,7 @@ resource "azurerm_kubernetes_cluster" "main" {
   location            = "${var.location}"
   resource_group_name = "${var.resource_group_name}"
   dns_prefix          = "${var.prefix}"
-  kubernetes_version  = "1.11.3"
+  kubernetes_version  = "${var.kubernetes_version}"
 
   linux_profile {
     admin_username = "${var.admin_username}"

--- a/modules/kubernetes-cluster/variables.tf
+++ b/modules/kubernetes-cluster/variables.tf
@@ -36,6 +36,11 @@ variable "agents_size" {
   description = "The Azure VM Size of the Virtual Machines used in the Agent Pool"
 }
 
+variable "kubernetes_version" {
+  description = "Version of Kubernetes to install"
+  default     = "1.11.3"
+}
+
 variable "service_principal_client_id" {
   description = "The Client ID of the Service Principal assigned to Kubernetes"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,11 @@ variable "agents_count" {
   default     = 2
 }
 
+variable "kubernetes_version" {
+  description = "Version of Kubernetes to install"
+  default     = "1.11.3"
+}
+
 variable "public_ssh_key" {
   description = "A custom ssh key to control access to the AKS cluster"
   default     = ""


### PR DESCRIPTION
Makes the hardcoded Kubernetes version in the kubernetes-cluster submodule configurable.

https://github.com/Azure/terraform-azurerm-aks/blob/7e38320cbec6d4e10b57780d65406c521b8e906d/modules/kubernetes-cluster/main.tf#L6

Fixes #6