### PR TITLE
Expose cluster connection info

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ variable "public_ssh_key" {
 }
 ```
 
+The module supports some outputs that may be used to configure a kubernetes
+provider after deploying an AKS cluster.
+
+```
+provider "kubernetes" {
+  host = "${module.aks.host}"
+
+  client_certificate     = "${base64decode(module.aks.client_certificate)}"
+  client_key             = "${base64decode(module.aks.client_key)}"
+  cluster_ca_certificate = "${base64decode(module.aks.cluster_ca_certificate)}"
+}
+```
+
 ## Authors
 
 Originally created by [Damien Caro](http://github.com/dcaro) and [Malte Lantin](http://github.com/n01d)

--- a/modules/kubernetes-cluster/outputs.tf
+++ b/modules/kubernetes-cluster/outputs.tf
@@ -29,3 +29,11 @@ output "password" {
 output "raw_kube_config" {
   value = "${azurerm_kubernetes_cluster.main.kube_config_raw}"
 }
+
+output "node_resource_group" {
+  value = "${azurerm_kubernetes_cluster.main.node_resource_group}"
+}
+
+output "location" {
+  value = "${azurerm_kubernetes_cluster.main.location}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,31 @@
+output "client_key" {
+  value = "${module.kubernetes.client_key}"
+}
+
+output "client_certificate" {
+  value = "${module.kubernetes.client_certificate}"
+}
+
+output "cluster_ca_certificate" {
+  value = "${module.kubernetes.cluster_ca_certificate}"
+}
+
+output "host" {
+  value = "${module.kubernetes.host}"
+}
+
+output "username" {
+  value = "${module.kubernetes.username}"
+}
+
+output "password" {
+  value = "${module.kubernetes.password}"
+}
+
+output "node_resource_group" {
+  value = "${module.kubernetes.node_resource_group}"
+}
+
+output "location" {
+  value = "${module.kubernetes.location}"
+}


### PR DESCRIPTION
Exposes the cluster info outside of this terraform module so they may be used to set up the terraform azurerm provider. See the README for an example of how to provide the outputs to the kubernetes provider.