### PR TITLE
fix #21 delete duplicate workspace_name

### DIFF
--- a/modules/log-analytics-solution/main.tf
+++ b/modules/log-analytics-solution/main.tf
@@ -1,6 +1,5 @@
 resource "azurerm_log_analytics_solution" "main" {
   solution_name         = "ContainerInsights"
-  workspace_name        = "${var.prefix}-log-analytics-workspace"
   location              = "${var.location}"
   resource_group_name   = "${var.resource_group_name}"
   workspace_resource_id = "${var.workspace_resource_id}"


### PR DESCRIPTION
The variable `workspace_name` was defined twice causing an error on `terraform init`. This value should correspond to the name of the Azure Log Analytics workspace which it'll be working with.

See https://www.terraform.io/docs/providers/azurerm/r/log_analytics_solution.html#workspace_name 