### PR TITLE
fix #20, Upgrade to v12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,41 +1,42 @@
 resource "azurerm_resource_group" "main" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 module "ssh-key" {
   source         = "./modules/ssh-key"
-  public_ssh_key = "${var.public_ssh_key == "" ? "" : var.public_ssh_key }"
+  public_ssh_key = var.public_ssh_key == "" ? "" : var.public_ssh_key
 }
 
 module "kubernetes" {
   source                          = "./modules/kubernetes-cluster"
-  prefix                          = "${var.prefix}"
-  resource_group_name             = "${azurerm_resource_group.main.name}"
-  location                        = "${azurerm_resource_group.main.location}"
-  admin_username                  = "${var.admin_username}"
-  admin_public_ssh_key            = "${var.public_ssh_key == "" ? module.ssh-key.public_ssh_key : var.public_ssh_key }"
-  agents_size                     = "${var.agents_size}"
-  agents_count                    = "${var.agents_count}"
-  kubernetes_version              = "${var.kubernetes_version}"
-  service_principal_client_id     = "${var.CLIENT_ID}"
-  service_principal_client_secret = "${var.CLIENT_SECRET}"
-  log_analytics_workspace_id      = "${module.log_analytics_workspace.id}"
+  prefix                          = var.prefix
+  resource_group_name             = azurerm_resource_group.main.name
+  location                        = azurerm_resource_group.main.location
+  admin_username                  = var.admin_username
+  admin_public_ssh_key            = var.public_ssh_key == "" ? module.ssh-key.public_ssh_key : var.public_ssh_key
+  agents_size                     = var.agents_size
+  agents_count                    = var.agents_count
+  kubernetes_version              = var.kubernetes_version
+  service_principal_client_id     = var.CLIENT_ID
+  service_principal_client_secret = var.CLIENT_SECRET
+  log_analytics_workspace_id      = module.log_analytics_workspace.id
 }
 
 module "log_analytics_workspace" {
   source              = "./modules/log-analytics-workspace"
-  prefix              = "${var.prefix}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
-  location            = "${azurerm_resource_group.main.location}"
-  retention_in_days   = "${var.log_retention_in_days}"
-  sku                 = "${var.log_analytics_workspace_sku}"
+  prefix              = var.prefix
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  retention_in_days   = var.log_retention_in_days
+  sku                 = var.log_analytics_workspace_sku
 }
 
 module "log_analytics_solution" {
   source                = "./modules/log-analytics-solution"
-  resource_group_name   = "${azurerm_resource_group.main.name}"
-  location              = "${azurerm_resource_group.main.location}"
-  workspace_resource_id = "${module.log_analytics_workspace.id}"
-  workspace_name        = "${module.log_analytics_workspace.name}"
+  resource_group_name   = azurerm_resource_group.main.name
+  location              = azurerm_resource_group.main.location
+  workspace_resource_id = module.log_analytics_workspace.id
+  workspace_name        = module.log_analytics_workspace.name
 }
+

--- a/modules/kubernetes-cluster/main.tf
+++ b/modules/kubernetes-cluster/main.tf
@@ -1,38 +1,39 @@
 resource "azurerm_kubernetes_cluster" "main" {
   name                = "${var.prefix}-aks"
-  location            = "${var.location}"
-  resource_group_name = "${var.resource_group_name}"
-  dns_prefix          = "${var.prefix}"
-  kubernetes_version  = "${var.kubernetes_version}"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  dns_prefix          = var.prefix
+  kubernetes_version  = var.kubernetes_version
 
   linux_profile {
-    admin_username = "${var.admin_username}"
+    admin_username = var.admin_username
 
     ssh_key {
       # remove any new lines using the replace interpolation function
-      key_data = "${replace(var.admin_public_ssh_key, "\n", "")}"
+      key_data = replace(var.admin_public_ssh_key, "\n", "")
     }
   }
 
   agent_pool_profile {
     name            = "nodepool"
-    count           = "${var.agents_count}"
-    vm_size         = "${var.agents_size}"
+    count           = var.agents_count
+    vm_size         = var.agents_size
     os_type         = "Linux"
     os_disk_size_gb = 50
   }
 
   service_principal {
-    client_id     = "${var.service_principal_client_id}"
-    client_secret = "${var.service_principal_client_secret}"
+    client_id     = var.service_principal_client_id
+    client_secret = var.service_principal_client_secret
   }
 
   addon_profile {
     oms_agent {
       enabled                    = true
-      log_analytics_workspace_id = "${var.log_analytics_workspace_id}"
+      log_analytics_workspace_id = var.log_analytics_workspace_id
     }
   }
 
-  tags = "${var.tags}"
+  tags = var.tags
 }
+

--- a/modules/kubernetes-cluster/outputs.tf
+++ b/modules/kubernetes-cluster/outputs.tf
@@ -1,39 +1,40 @@
 output "cluster_id" {
-  value = "${azurerm_kubernetes_cluster.main.id}"
+  value = azurerm_kubernetes_cluster.main.id
 }
 
 output "client_key" {
-  value = "${azurerm_kubernetes_cluster.main.kube_config.0.client_key}"
+  value = azurerm_kubernetes_cluster.main.kube_config[0].client_key
 }
 
 output "client_certificate" {
-  value = "${azurerm_kubernetes_cluster.main.kube_config.0.client_certificate}"
+  value = azurerm_kubernetes_cluster.main.kube_config[0].client_certificate
 }
 
 output "cluster_ca_certificate" {
-  value = "${azurerm_kubernetes_cluster.main.kube_config.0.cluster_ca_certificate}"
+  value = azurerm_kubernetes_cluster.main.kube_config[0].cluster_ca_certificate
 }
 
 output "host" {
-  value = "${azurerm_kubernetes_cluster.main.kube_config.0.host}"
+  value = azurerm_kubernetes_cluster.main.kube_config[0].host
 }
 
 output "username" {
-  value = "${azurerm_kubernetes_cluster.main.kube_config.0.username}"
+  value = azurerm_kubernetes_cluster.main.kube_config[0].username
 }
 
 output "password" {
-  value = "${azurerm_kubernetes_cluster.main.kube_config.0.password}"
+  value = azurerm_kubernetes_cluster.main.kube_config[0].password
 }
 
 output "raw_kube_config" {
-  value = "${azurerm_kubernetes_cluster.main.kube_config_raw}"
+  value = azurerm_kubernetes_cluster.main.kube_config_raw
 }
 
 output "node_resource_group" {
-  value = "${azurerm_kubernetes_cluster.main.node_resource_group}"
+  value = azurerm_kubernetes_cluster.main.node_resource_group
 }
 
 output "location" {
-  value = "${azurerm_kubernetes_cluster.main.location}"
+  value = azurerm_kubernetes_cluster.main.location
 }
+

--- a/modules/kubernetes-cluster/variables.tf
+++ b/modules/kubernetes-cluster/variables.tf
@@ -17,7 +17,7 @@ variable "location" {
 variable "tags" {
   default     = {}
   description = "Any tags that should be present on the Virtual Network resources"
-  type        = "map"
+  type        = map(string)
 }
 
 variable "admin_username" {
@@ -48,3 +48,4 @@ variable "service_principal_client_id" {
 variable "service_principal_client_secret" {
   description = "The Client Secret of the Service Principal assigned to Kubernetes"
 }
+

--- a/modules/log-analytics-solution/main.tf
+++ b/modules/log-analytics-solution/main.tf
@@ -1,6 +1,5 @@
 resource "azurerm_log_analytics_solution" "main" {
   solution_name         = "ContainerInsights"
-  workspace_name        = "${var.prefix}-log-analytics-workspace"
   location              = "${var.location}"
   resource_group_name   = "${var.resource_group_name}"
   workspace_resource_id = "${var.workspace_resource_id}"

--- a/modules/log-analytics-solution/main.tf
+++ b/modules/log-analytics-solution/main.tf
@@ -1,12 +1,13 @@
 resource "azurerm_log_analytics_solution" "main" {
   solution_name         = "ContainerInsights"
-  location              = "${var.location}"
-  resource_group_name   = "${var.resource_group_name}"
-  workspace_resource_id = "${var.workspace_resource_id}"
-  workspace_name        = "${var.workspace_name}"
+  location              = var.location
+  resource_group_name   = var.resource_group_name
+  workspace_resource_id = var.workspace_resource_id
+  workspace_name        = var.workspace_name
 
   plan {
     publisher = "Microsoft"
     product   = "OMSGallery/ContainerInsights"
   }
 }
+

--- a/modules/log-analytics-solution/outputs.tf
+++ b/modules/log-analytics-solution/outputs.tf
@@ -1,3 +1,4 @@
 output "id" {
-  value = "${azurerm_log_analytics_solution.main.id}"
+  value = azurerm_log_analytics_solution.main.id
 }
+

--- a/modules/log-analytics-solution/variables.tf
+++ b/modules/log-analytics-solution/variables.tf
@@ -13,3 +13,4 @@ variable "workspace_resource_id" {
 variable "workspace_name" {
   description = "The name of the workspace created for Log Analytics"
 }
+

--- a/modules/log-analytics-workspace/main.tf
+++ b/modules/log-analytics-workspace/main.tf
@@ -1,7 +1,8 @@
 resource "azurerm_log_analytics_workspace" "main" {
   name                = "${var.prefix}-log-analytics-workspace"
-  location            = "${var.location}"
-  resource_group_name = "${var.resource_group_name}"
-  sku                 = "${var.sku}"
-  retention_in_days   = "${var.retention_in_days}"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  sku                 = var.sku
+  retention_in_days   = var.retention_in_days
 }
+

--- a/modules/log-analytics-workspace/outputs.tf
+++ b/modules/log-analytics-workspace/outputs.tf
@@ -1,7 +1,8 @@
 output "id" {
-  value = "${azurerm_log_analytics_workspace.main.id}"
+  value = azurerm_log_analytics_workspace.main.id
 }
 
 output "name" {
-  value = "${azurerm_log_analytics_workspace.main.name}"
+  value = azurerm_log_analytics_workspace.main.name
 }
+

--- a/modules/log-analytics-workspace/variables.tf
+++ b/modules/log-analytics-workspace/variables.tf
@@ -29,3 +29,4 @@ variable "log_retention_in_days" {
   description = "The retention period for the logs in days"
   default     = 30
 }
+

--- a/modules/ssh-key/main.tf
+++ b/modules/ssh-key/main.tf
@@ -4,17 +4,18 @@ resource "tls_private_key" "ssh" {
 }
 
 resource "local_file" "private_key" {
-  count    = "${var.public_ssh_key == "" ? 1 : 0}"
-  content  = "${tls_private_key.ssh.private_key_pem}"
+  count    = var.public_ssh_key == "" ? 1 : 0
+  content  = tls_private_key.ssh.private_key_pem
   filename = "./private_ssh_key"
 }
 
 output "public_ssh_key" {
   # Only output a generated ssh public key
-  value = "${var.public_ssh_key != "" ? "" : tls_private_key.ssh.public_key_openssh}"
+  value = var.public_ssh_key != "" ? "" : tls_private_key.ssh.public_key_openssh
 }
 
 variable "public_ssh_key" {
   description = "An ssh key set in the main variables of the terraform-azurerm-aks module"
   default     = ""
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,31 +1,32 @@
 output "client_key" {
-  value = "${module.kubernetes.client_key}"
+  value = module.kubernetes.client_key
 }
 
 output "client_certificate" {
-  value = "${module.kubernetes.client_certificate}"
+  value = module.kubernetes.client_certificate
 }
 
 output "cluster_ca_certificate" {
-  value = "${module.kubernetes.cluster_ca_certificate}"
+  value = module.kubernetes.cluster_ca_certificate
 }
 
 output "host" {
-  value = "${module.kubernetes.host}"
+  value = module.kubernetes.host
 }
 
 output "username" {
-  value = "${module.kubernetes.username}"
+  value = module.kubernetes.username
 }
 
 output "password" {
-  value = "${module.kubernetes.password}"
+  value = module.kubernetes.password
 }
 
 output "node_resource_group" {
-  value = "${module.kubernetes.node_resource_group}"
+  value = module.kubernetes.node_resource_group
 }
 
 output "location" {
-  value = "${module.kubernetes.location}"
+  value = module.kubernetes.location
 }
+

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "=1.16.0"
+  version = "~> 1.27"
 }
 
 resource "random_string" "prefix" {

--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,4 @@ variable "public_ssh_key" {
   description = "A custom ssh key to control access to the AKS cluster"
   default     = ""
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Upgraded to terraform version 0.12. This PR is on top of a previous bugfix (#21) and the only major change is the `azurerm` version in the fixture has changed from `=1.16.0` to `~> 1.27`, which is the lowest version the azure provider supports terraform 0.12. 