### PR TITLE
The Kuberenetes versions are outdated 

### DIFF
--- a/modules/kubernetes-cluster/variables.tf
+++ b/modules/kubernetes-cluster/variables.tf
@@ -38,7 +38,7 @@ variable "agents_size" {
 
 variable "kubernetes_version" {
   description = "Version of Kubernetes to install"
-  default     = "1.11.3"
+  default     = "1.14.8"
 }
 
 variable "service_principal_client_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "agents_count" {
 
 variable "kubernetes_version" {
   description = "Version of Kubernetes to install"
-  default     = "1.14.5"
+  default     = "1.14.8"
 }
 
 variable "public_ssh_key" {


### PR DESCRIPTION
version 1.14.5 is not available in multiple regions and the error you'd get with it is:

```
Error: Error creating Managed Kubernetes Cluster "yes-aks" (Resource Group "yes-resources"): containerservice.ManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="AgentPoolK8sVersionNotSupported" Message="Version 1.14.5 is not supported inthis region. Please use [az aks get-versions] command to get the supported version list in this region. For more information, please check https://aka.ms/supported-version-list"

  on tf-module/modules/kubernetes-cluster/main.tf line 1, in resource "azurerm_kubernetes_cluster" "main":
   1: resource "azurerm_kubernetes_cluster" "main" {
```

the following are the supported versions:

KubernetesVersion    Upgrades
-------------------  ----------------------------------------
1.15.5(preview)      None available
1.15.4(preview)      1.15.5(preview)
1.14.8               1.15.4(preview), 1.15.5(preview)
1.14.7               1.14.8, 1.15.4(preview), 1.15.5(preview)
1.13.12              1.14.7, 1.14.8
1.13.11              1.13.12, 1.14.7, 1.14.8
1.12.8               1.13.11, 1.13.12
1.12.7               1.12.8, 1.13.11, 1.13.12
1.11.10              1.12.7, 1.12.8
1.11.9               1.11.10, 1.12.7, 1.12.8
1.10.13              1.11.9, 1.11.10
1.10.12              1.10.13, 1.11.9, 1.11.10