### PR TITLE
Update the template validation pipeline to use the latest testing image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Pull the base image with given version.
-ARG BUILD_TERRAFORM_VERSION=0.11.7
-FROM microsoft/terraform-test:${BUILD_TERRAFORM_VERSION}
+ARG BUILD_TERRAFORM_VERSION=0.12.10
+FROM mcr.microsoft.com/terraform-test:${BUILD_TERRAFORM_VERSION}
 
 ARG MODULE_NAME="terraform-azurerm-aks"
 

--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,7 @@ COMMANDS=()
 if [ $1 == "validate" ] || [ $1 == "full" ]
 then
     COMMANDS+=("terraform fmt -check=true")
-    COMMANDS+=("terraform validate -check-variables=false")
+    COMMANDS+=("terraform validate")
     COMMANDS+=("dep ensure")
 fi
 

--- a/test.sh
+++ b/test.sh
@@ -21,6 +21,7 @@ COMMANDS=()
 if [ $1 == "validate" ] || [ $1 == "full" ]
 then
     COMMANDS+=("terraform fmt -check=true")
+    COMMANDS+=("terraform init -backend=false")
     COMMANDS+=("terraform validate")
     COMMANDS+=("dep ensure")
 fi


### PR DESCRIPTION
Update the template validation pipeline to use the latest testing image. The new image image is pulled from the Microsoft container registry and contains 0.12 which is required by the template.