### PR TITLE
Make `client_id` `client_secret` Optional, add `SystemAssigned` identity if service principal is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 This Terraform module deploys a Kubernetes cluster on Azure using AKS (Azure Kubernetes Service) and adds support for monitoring with Log Analytics.
 
+-> **NOTE:** If you have not assigned `client_id` or `client_secret`, A `SystemAssigned` identity will be created.
+
 ## Usage in Terraform 0.13
 
 ```hcl
@@ -27,6 +29,8 @@ module "network" {
 module "aks" {
   source              = "Azure/aks/azurerm"
   resource_group_name = azurerm_resource_group.example.name
+  client_id           = "your-service-principal-client-appid"
+  client_secret       = "your-service-principal-client-password"
   prefix              = "prefix"
   vnet_subnet_id      = module.network.vnet_subnets[0]
   os_disk_size_gb     = 50
@@ -107,6 +111,10 @@ $ export ARM_TENANT_ID="tenant-id"
 $ export ARM_TEST_LOCATION="eastus"
 $ export ARM_TEST_LOCATION_ALT="eastus2"
 $ export ARM_TEST_LOCATION_ALT2="westus"
+
+# set aks variables
+$ export TF_VAR_client_id="service-principal-client-id"
+$ export TF_VAR_client_secret="service-principal-client-secret"
 
 # run test
 $ rake build

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ module "network" {
 module "aks" {
   source              = "Azure/aks/azurerm"
   resource_group_name = azurerm_resource_group.example.name
-  client_id           = "your-service-principal-client-appid"
-  client_secret       = "your-service-principal-client-password"
   prefix              = "prefix"
   vnet_subnet_id      = module.network.vnet_subnets[0]
   os_disk_size_gb     = 50
@@ -52,8 +50,6 @@ resource "azurerm_resource_group" "example" {
 module "aks" {
   source              = "Azure/aks/azurerm"
   resource_group_name = azurerm_resource_group.example.name
-  client_id           = "your-service-principal-client-appid"
-  client_secret       = "your-service-principal-client-password"
   prefix              = "prefix"
 }
 ```
@@ -111,10 +107,6 @@ $ export ARM_TENANT_ID="tenant-id"
 $ export ARM_TEST_LOCATION="eastus"
 $ export ARM_TEST_LOCATION_ALT="eastus2"
 $ export ARM_TEST_LOCATION_ALT2="westus"
-
-# set aks variables
-$ export TF_VAR_client_id="service-principal-client-id"
-$ export TF_VAR_client_secret="service-principal-client-secret"
 
 # run test
 $ rake build

--- a/main.tf
+++ b/main.tf
@@ -30,9 +30,19 @@ resource "azurerm_kubernetes_cluster" "main" {
     vnet_subnet_id  = var.vnet_subnet_id
   }
 
-  service_principal {
-    client_id     = var.client_id
-    client_secret = var.client_secret
+  dynamic service_principal {
+    for_each = var.client_id != "" && var.client_secret != "" ? ["service_principal"] : []
+    content {
+      client_id     = var.client_id
+      client_secret = var.client_secret
+    }
+  }
+
+  dynamic identity {
+    for_each = var.identity_type != "" ? ["identity"] : []
+    content {
+      type = var.identity_type
+    }
   }
 
   addon_profile {

--- a/main.tf
+++ b/main.tf
@@ -39,9 +39,9 @@ resource "azurerm_kubernetes_cluster" "main" {
   }
 
   dynamic identity {
-    for_each = var.identity_type != "" ? ["identity"] : []
+    for_each = var.client_id == "" || var.client_secret == "" ? ["identity"] : []
     content {
-      type = var.identity_type
+      type = "SystemAssigned"
     }
   }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,5 +39,9 @@ output "kube_config_raw" {
 }
 
 output "http_application_routing_zone_name" {
-  value = azurerm_kubernetes_cluster.main.addon_profile[0].http_application_routing[0].http_application_routing_zone_name
+  value = length(azurerm_kubernetes_cluster.main.addon_profile) > 0 && length(azurerm_kubernetes_cluster.main.addon_profile[0].http_application_routing) > 0 ? azurerm_kubernetes_cluster.main.addon_profile[0].http_application_routing[0].http_application_routing_zone_name : ""
+}
+
+output "system_assigned_identity" {
+  value = azurerm_kubernetes_cluster.main.identity
 }

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -40,8 +40,6 @@ module aks_without_monitor {
   source                         = "../.."
   prefix                         = "prefix2-${random_id.prefix.hex}"
   resource_group_name            = azurerm_resource_group.main.name
-  client_id                      = var.client_id
-  client_secret                  = var.client_secret
   enable_log_analytics_workspace = false
   depends_on                     = [azurerm_resource_group.main]
 }

--- a/test/fixture/outputs.tf
+++ b/test/fixture/outputs.tf
@@ -1,3 +1,11 @@
 output "test_aks_id" {
   value = module.aks.aks_id
 }
+
+output "test_aks_without_monitor_id" {
+  value = module.aks_without_monitor.aks_id
+}
+
+output "test_aks_without_monitor_identity" {
+  value = module.aks_without_monitor.system_assigned_identity
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,13 +9,13 @@ variable "prefix" {
 }
 
 variable "client_id" {
-  description = "The Client ID (appId) for the Service Principal used for the AKS deployment"
+  description = "(Optional) The Client ID (appId) for the Service Principal used for the AKS deployment"
   type        = string
   default     = ""
 }
 
 variable "client_secret" {
-  description = "The Client Secret (password) for the Service Principal used for the AKS deployment"
+  description = "(Optional) The Client Secret (password) for the Service Principal used for the AKS deployment"
   type        = string
   default     = ""
 }
@@ -84,10 +84,4 @@ variable "enable_http_application_routing" {
   description = "Enable HTTP Application Routing Addon (forces recreation)."
   type        = bool
   default     = false
-}
-
-variable "identity_type" {
-  description = "The type of identity used for the managed cluster.One of either `identity_type` or `service_principal` must be specified."
-  type        = string
-  default     = "SystemAssigned"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,11 +11,13 @@ variable "prefix" {
 variable "client_id" {
   description = "The Client ID (appId) for the Service Principal used for the AKS deployment"
   type        = string
+  default     = ""
 }
 
 variable "client_secret" {
   description = "The Client Secret (password) for the Service Principal used for the AKS deployment"
   type        = string
+  default     = ""
 }
 
 variable "admin_username" {
@@ -82,4 +84,10 @@ variable "enable_http_application_routing" {
   description = "Enable HTTP Application Routing Addon (forces recreation)."
   type        = bool
   default     = false
+}
+
+variable "identity_type" {
+  description = "The type of identity used for the managed cluster.One of either `identity_type` or `service_principal` must be specified."
+  type        = string
+  default     = "SystemAssigned"
 }


### PR DESCRIPTION
Fix https://github.com/Azure/terraform-azurerm-aks/issues/50

Sorry for the previous not merged `http_application_routing_zone_name` has to be added again here.