### PR TITLE
add variable to enable_kube_dashboard

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,10 @@ resource "azurerm_kubernetes_cluster" "main" {
       enabled = var.enable_http_application_routing
     }
 
+    kube_dashboard {
+      enabled = var.enable_kube_dashboard
+    }
+
     dynamic azure_policy {
       for_each = var.enable_azure_policy ? ["azure_policy"] : []
       content {

--- a/variables.tf
+++ b/variables.tf
@@ -92,6 +92,12 @@ variable "enable_azure_policy" {
   default     = false
 }
 
+variable "enable_kube_dashboard" {
+  description = "Enable Kubernetes web dashboard. NOTE: This add-on is set for deprecation. [https://docs.microsoft.com/en-us/azure/aks/kubernetes-dashboard]"
+  type        = bool
+  default     = false
+}
+
 variable "sku_tier" {
   description = "The SKU Tier that should be used for this Kubernetes Cluster. Possible values are Free and Paid"
   type        = string


### PR DESCRIPTION
closes #47 

add variable to enable/disable the kube_dashboard.

defaults to `false`