### PR TITLE
Add support for private cluster API access.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ module "aks" {
   enable_role_based_access_control = true
   rbac_aad_admin_group_object_ids  = [data.azuread_group.aks_cluster_admins.id]
   rbac_aad_managed                 = true
-
-  private_cluster_enabled = false # default value
+  private_cluster_enabled          = true # default value
 
   depends_on = [module.network]
 }

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ module "aks" {
   enable_azure_policy = true
   sku_tier            = "Paid" # defaults to Free
 
+  private_cluster_enabled = false # default value
+
   depends_on = [module.network]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ module "aks" {
   vnet_subnet_id      = module.network.vnet_subnets[0]
   os_disk_size_gb     = 50
   enable_azure_policy = true
+  sku_tier            = "Paid" # defaults to Free
 
   depends_on = [module.network]
 }

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ resource "azurerm_kubernetes_cluster" "main" {
   location            = data.azurerm_resource_group.main.location
   resource_group_name = data.azurerm_resource_group.main.name
   dns_prefix          = var.prefix
+  sku_tier            = var.sku_tier
 
   linux_profile {
     admin_username = var.admin_username

--- a/main.tf
+++ b/main.tf
@@ -8,12 +8,11 @@ module "ssh-key" {
 }
 
 resource "azurerm_kubernetes_cluster" "main" {
-  name                = "${var.prefix}-aks"
-  location            = data.azurerm_resource_group.main.location
-  resource_group_name = data.azurerm_resource_group.main.name
-  dns_prefix          = var.prefix
-  sku_tier            = var.sku_tier
-
+  name                    = "${var.prefix}-aks"
+  location                = data.azurerm_resource_group.main.location
+  resource_group_name     = data.azurerm_resource_group.main.name
+  dns_prefix              = var.prefix
+  sku_tier                = var.sku_tier
   private_cluster_enabled = var.private_cluster_enabled
 
   linux_profile {

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,8 @@ resource "azurerm_kubernetes_cluster" "main" {
   dns_prefix          = var.prefix
   sku_tier            = var.sku_tier
 
+  private_cluster_enabled = var.private_cluster_enabled
+
   linux_profile {
     admin_username = var.admin_username
 

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -37,6 +37,7 @@ module aks {
   enable_azure_policy             = true
   sku_tier                        = "Paid"
   enable_kube_dashboard           = true
+  private_cluster_enabled         = false
   depends_on                      = [azurerm_resource_group.main]
 }
 

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -34,6 +34,7 @@ module aks {
   os_disk_size_gb                 = 60
   enable_http_application_routing = true
   enable_azure_policy             = true
+  sku_tier                        = "Paid"
   depends_on                      = [azurerm_resource_group.main]
 }
 

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -37,7 +37,7 @@ module aks {
   enable_azure_policy             = true
   sku_tier                        = "Paid"
   enable_kube_dashboard           = true
-  private_cluster_enabled         = false
+  private_cluster_enabled         = true
   depends_on                      = [azurerm_resource_group.main]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -80,6 +80,12 @@ variable "os_disk_size_gb" {
   default     = 50
 }
 
+variable "private_cluster_enabled" {
+  description = "If true cluster API server will be exposed only on internal IP address and available only in cluster vnet."
+  type        = bool
+  default     = false
+}
+
 variable "enable_http_application_routing" {
   description = "Enable HTTP Application Routing Addon (forces recreation)."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -91,3 +91,9 @@ variable "enable_azure_policy" {
   type        = bool
   default     = false
 }
+
+variable "sku_tier" {
+  description = "The SKU Tier that should be used for this Kubernetes Cluster. Possible values are Free and Paid"
+  type        = string
+  default     = "Free"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,7 @@ variable "private_cluster_enabled" {
   description = "If true cluster API server will be exposed only on internal IP address and available only in cluster vnet."
   type        = bool
   default     = false
+}
 
 variable "enable_kube_dashboard" {
   description = "Enable Kubernetes Dashboard."


### PR DESCRIPTION
Hello, this is my first PR for this project. I've started using this module recently to manage my AKS cluster in my infrastructure.

I've added new variable because I'd like to restrict cluster access from internet in my infrastructure.

This change doesn't broke module behaviour because default is `false`. Default AKS cluster installation exposes API over internet as before.

Please let me know how do you think about this change.