### PR TITLE
Set minimal provider required version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,11 @@
 
 terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 2.34.0"
+    }    
+  }
+
   required_version = ">= 0.12"
 }


### PR DESCRIPTION
Support for `tags` in `azurerm_log_analytics_solution` has been added in v2.34.0
