### PR TITLE
Add support for nodepool autoscaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ module "aks" {
   enable_role_based_access_control = true
   rbac_aad_admin_group_object_ids  = [data.azuread_group.aks_cluster_admins.id]
   rbac_aad_managed                 = true
+  enable_auto_scaling              = true
+  agents_min_count                 = 1
+  agents_max_count                 = 2
 
   depends_on = [module.network]
 }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ module "aks" {
   enable_auto_scaling              = true
   agents_min_count                 = 1
   agents_max_count                 = 2
-  
+ 
   depends_on = [module.network]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ module "aks" {
   enable_auto_scaling              = true
   agents_min_count                 = 1
   agents_max_count                 = 2
- 
+
   depends_on = [module.network]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ module "aks" {
   enable_auto_scaling              = true
   agents_min_count                 = 1
   agents_max_count                 = 2
+  agents_count                     = null
 
   depends_on = [module.network]
 }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ module "aks" {
   enable_auto_scaling              = true
   agents_min_count                 = 1
   agents_max_count                 = 2
-  agents_count                     = null
+  agents_count                     = null # Please set `agents_count` `null` while `enable_auto_scaling` is `true` to avoid possible `agents_count` changes.
 
   depends_on = [module.network]
 }

--- a/main.tf
+++ b/main.tf
@@ -24,11 +24,14 @@ resource "azurerm_kubernetes_cluster" "main" {
   }
 
   default_node_pool {
-    name            = "nodepool"
-    node_count      = var.agents_count
-    vm_size         = var.agents_size
-    os_disk_size_gb = var.os_disk_size_gb
-    vnet_subnet_id  = var.vnet_subnet_id
+    name                = "nodepool"
+    node_count          = var.agents_count
+    vm_size             = var.agents_size
+    os_disk_size_gb     = var.os_disk_size_gb
+    vnet_subnet_id      = var.vnet_subnet_id
+    enable_auto_scaling = var.enable_auto_scaling
+    max_count           = var.enable_auto_scaling ? var.agents_max_count : null
+    min_count           = var.enable_auto_scaling ? var.agents_min_count : null
   }
 
   dynamic service_principal {
@@ -116,7 +119,7 @@ resource "azurerm_log_analytics_solution" "main" {
     publisher = "Microsoft"
     product   = "OMSGallery/ContainerInsights"
   }
-  
+
   tags = var.tags
 }
 

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -43,7 +43,8 @@ module "aks" {
   enable_auto_scaling             = true
   agents_min_count                = 1
   agents_max_count                = 2
-  depends_on                      = [azurerm_resource_group.main]
+
+  depends_on = [azurerm_resource_group.main]
 }
   
 module "aks_without_monitor" {

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -43,6 +43,7 @@ module "aks" {
   enable_auto_scaling             = true
   agents_min_count                = 1
   agents_max_count                = 2
+  agents_count                    = null
 
   depends_on = [azurerm_resource_group.main]
 }

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -46,7 +46,7 @@ module "aks" {
 
   depends_on = [azurerm_resource_group.main]
 }
-  
+
 module "aks_without_monitor" {
   source                         = "../.."
   prefix                         = "prefix2-${random_id.prefix.hex}"

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -38,6 +38,17 @@ module aks {
   depends_on                      = [azurerm_resource_group.main]
 }
 
+module aks_with_scaling {
+  source              = "../.."
+  prefix              = "prefix-${random_id.prefix.hex}"
+  resource_group_name = azurerm_resource_group.main.name
+  enable_auto_scaling = true
+  agents_min_count    = 1
+  agents_max_count    = 2
+
+  depends_on = [azurerm_resource_group.main]
+}
+
 module aks_without_monitor {
   source                         = "../.."
   prefix                         = "prefix2-${random_id.prefix.hex}"

--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,7 @@ variable "log_retention_in_days" {
 }
 
 variable "agents_count" {
-  description = "The number of Agents that should exist in the Agent Pool"
+  description = "The number of Agents that should exist in the Agent Pool. Please set `agents_count` `null` while `enable_auto_scaling` is `true` to avoid possible `agents_count` changes."
   type        = number
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -47,7 +47,7 @@ variable "log_retention_in_days" {
 variable "agents_count" {
   description = "The number of Agents that should exist in the Agent Pool. Please set `agents_count` `null` while `enable_auto_scaling` is `true` to avoid possible `agents_count` changes."
   type        = number
-  default     = null
+  default     = 2
 }
 
 variable "public_ssh_key" {

--- a/variables.tf
+++ b/variables.tf
@@ -179,3 +179,5 @@ variable "agents_max_count" {
 variable "agents_min_count" {
   type        = number
   description = "Minimum number of nodes in a pool"
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -47,7 +47,7 @@ variable "log_retention_in_days" {
 variable "agents_count" {
   description = "The number of Agents that should exist in the Agent Pool"
   type        = number
-  default     = 2
+  default     = null
 }
 
 variable "public_ssh_key" {

--- a/variables.tf
+++ b/variables.tf
@@ -133,3 +133,21 @@ variable "rbac_aad_server_app_secret" {
   type        = string
   default     = null
 }
+
+variable "enable_auto_scaling" {
+  description = "Enable node pool autoscaling"
+  type        = bool
+  default     = false
+}
+
+variable "agents_max_count" {
+  type        = number
+  description = "Maximum number of nodes in a pool"
+  default     = null
+}
+
+variable "agents_min_count" {
+  type        = number
+  description = "Minimum number of nodes in a pool"
+  default     = null
+}


### PR DESCRIPTION
Changes proposed in the pull request:

Add support for nodepool autoscaling with the following configuration to the module:
```hcl
  enable_auto_scaling  = true
  agents_min_count     = 1
  agents_max_count     = 2
```
Note: To build the custom image to run the tests I needed to comment the following lines on the Dockerfile:
```dockerfile
# RUN mkdir /go
# RUN mkdir /go/bin
# RUN mkdir /go/src
```
Otherwise, the following error would happen:
```
 ---> Using cache
 ---> 46c203d86fc0
Step 18/28 : RUN mkdir /go
 ---> Running in e91071d40948
mkdir: cannot create directory ‘/go’: File exists
The command '/bin/sh -c mkdir /go' returned a non-zero code: 1
```
The base image already has the `go` folders in it.