### PR TITLE
Support setting network_plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ module "aks" {
   client_id                        = "your-service-principal-client-appid"
   client_secret                    = "your-service-principal-client-password"
   prefix                           = "prefix"
+  network_plugin                   = "azure"
   vnet_subnet_id                   = module.network.vnet_subnets[0]
   os_disk_size_gb                  = 50
   enable_kube_dashboard            = true

--- a/main.tf
+++ b/main.tf
@@ -96,6 +96,10 @@ resource "azurerm_kubernetes_cluster" "main" {
     }
   }
 
+  network_profile {
+    network_plugin = var.network_plugin
+  }
+
   tags = var.tags
 }
 

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -30,6 +30,7 @@ module aks {
   resource_group_name             = azurerm_resource_group.main.name
   client_id                       = var.client_id
   client_secret                   = var.client_secret
+  network_plugin                  = "azure"
   vnet_subnet_id                  = azurerm_subnet.test.id
   os_disk_size_gb                 = 60
   enable_http_application_routing = true

--- a/variables.tf
+++ b/variables.tf
@@ -139,3 +139,9 @@ variable "rbac_aad_server_app_secret" {
   type        = string
   default     = null
 }
+
+variable "network_plugin" {
+  description = "Network plugin to use for networking."
+  type        = string
+  default     = "kubenet"
+}


### PR DESCRIPTION
I tried to run the tests, but I can't build the azure-aks image anymore:
```shell
docker build --no-cache --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-aks .
Sending build context to Docker daemon  719.4kB
Step 1/28 : ARG BUILD_TERRAFORM_VERSION="0.13.5"
Step 2/28 : FROM mcr.microsoft.com/terraform-test:${BUILD_TERRAFORM_VERSION}
 ---> 66859ff1c069
Step 3/28 : ARG MODULE_NAME="terraform-azurerm-aks"
 ---> Running in de6cb6b5b931
Removing intermediate container de6cb6b5b931
 ---> 4717706e9412
Step 4/28 : ARG BUILD_ARM_SUBSCRIPTION_ID=""
 ---> Running in 74e8b7de6720
Removing intermediate container 74e8b7de6720
 ---> 12480e35bfe9
Step 5/28 : ARG BUILD_ARM_CLIENT_ID=""
 ---> Running in dbff849ecdfe
Removing intermediate container dbff849ecdfe
 ---> fa8d885a90ab
Step 6/28 : ARG BUILD_ARM_CLIENT_SECRET=""
 ---> Running in 6459a55abece
Removing intermediate container 6459a55abece
 ---> f095ddb08f5a
Step 7/28 : ARG BUILD_ARM_TENANT_ID=""
 ---> Running in b875478ae312
Removing intermediate container b875478ae312
 ---> 706b0573dc07
Step 8/28 : ARG BUILD_ARM_TEST_LOCATION="WestEurope"
 ---> Running in 2897e8d0b3c1
Removing intermediate container 2897e8d0b3c1
 ---> 205c1b902daa
Step 9/28 : ARG BUILD_ARM_TEST_LOCATION_ALT="WestUS"
 ---> Running in 090e2625e228
Removing intermediate container 090e2625e228
 ---> b249b2b5bc4f
Step 10/28 : ENV ARM_SUBSCRIPTION_ID=${BUILD_ARM_SUBSCRIPTION_ID}
 ---> Running in d5f941c3d0ae
Removing intermediate container d5f941c3d0ae
 ---> 46ed56004210
Step 11/28 : ENV ARM_CLIENT_ID=${BUILD_ARM_CLIENT_ID}
 ---> Running in 1ac04e3f829c
Removing intermediate container 1ac04e3f829c
 ---> 2bfa6ef6f2ef
Step 12/28 : ENV ARM_CLIENT_SECRET=${BUILD_ARM_CLIENT_SECRET}
 ---> Running in 272e7decd390
Removing intermediate container 272e7decd390
 ---> 3ba637173348
Step 13/28 : ENV ARM_TENANT_ID=${BUILD_ARM_TENANT_ID}
 ---> Running in ab5442b0d120
Removing intermediate container ab5442b0d120
 ---> f94bf96caebb
Step 14/28 : ENV ARM_TEST_LOCATION=${BUILD_ARM_TEST_LOCATION}
 ---> Running in ade3ea96fe52
Removing intermediate container ade3ea96fe52
 ---> c70e974d7b8b
Step 15/28 : ENV ARM_TEST_LOCATION_ALT=${BUILD_ARM_TEST_LOCATION_ALT}
 ---> Running in e2967d72cf4e
Removing intermediate container e2967d72cf4e
 ---> 805823119063
Step 16/28 : ENV TF_VAR_client_id=${BUILD_ARM_CLIENT_ID}
 ---> Running in b67e1d0d7eed
Removing intermediate container b67e1d0d7eed
 ---> 80cb1b3f6863
Step 17/28 : ENV TF_VAR_client_secret=${BUILD_ARM_CLIENT_SECRET}
 ---> Running in ab2a298dc920
Removing intermediate container ab2a298dc920
 ---> 0ffcaee46da6
Step 18/28 : RUN mkdir /go
 ---> Running in 9a12584f1ea2
mkdir: cannot create directory ‘/go’: File exists
The command '/bin/sh -c mkdir /go' returned a non-zero code: 1
```
