### PR TITLE
Add cluster_name var

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,29 @@ module "aks" {
   rbac_aad_admin_group_object_ids  = [data.azuread_group.aks_cluster_admins.id]
   rbac_aad_managed                 = true
   private_cluster_enabled          = true # default value
+  enable_http_application_routing = true
+  enable_azure_policy             = true  
   enable_auto_scaling              = true
   agents_min_count                 = 1
   agents_max_count                 = 2
   agents_count                     = null # Please set `agents_count` `null` while `enable_auto_scaling` is `true` to avoid possible `agents_count` changes.
+  agents_max_pods                 = 100
+  agents_pool_name                = "defaultnodepool"
+  agents_availability_zones       = ["1", "2"]
+  agents_type                     = "VirtualMachineScaleSets"
+
+  agents_labels = {
+    "nodepool" : "defaultnodepool"
+  }
+
+  agents_tags = {
+    "Agent" : "defaultnodepoolagent"
+  }
+
+  network_policy                 = "azure"
+  net_profile_dns_service_ip     = "10.0.0.10"
+  net_profile_docker_bridge_cidr = "170.10.0.1/16"
+  net_profile_service_cidr       = "10.0.0.0/16"
 
   depends_on = [module.network]
 }

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ module "aks" {
   }
 
   network_policy                 = "azure"
-  net_profile_dns_service_ip     = "10.0.0.10"
+  net_profile_dns_service_ip     = "160.0.0.10"
   net_profile_docker_bridge_cidr = "170.10.0.1/16"
-  net_profile_service_cidr       = "10.0.0.0/16"
+  net_profile_service_cidr       = "160.0.0.0/16"
 
   depends_on = [module.network]
 }

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ module "aks" {
   rbac_aad_admin_group_object_ids  = [data.azuread_group.aks_cluster_admins.id]
   rbac_aad_managed                 = true
   private_cluster_enabled          = true # default value
+  enable_auto_scaling              = true
+  agents_min_count                 = 1
+  agents_max_count                 = 2
+  agents_count                     = null # Please set `agents_count` `null` while `enable_auto_scaling` is `true` to avoid possible `agents_count` changes.
 
   depends_on = [module.network]
 }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ module "aks" {
   resource_group_name              = azurerm_resource_group.example.name
   client_id                        = "your-service-principal-client-appid"
   client_secret                    = "your-service-principal-client-password"
+  kubernetes_version               = "1.19.3"
+  orchestrator_version             = "1.19.3"
   prefix                           = "prefix"
   network_plugin                   = "azure"
   vnet_subnet_id                   = module.network.vnet_subnets[0]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ module "aks" {
   enable_role_based_access_control = true
   rbac_aad_admin_group_object_ids  = [data.azuread_group.aks_cluster_admins.id]
   rbac_aad_managed                 = true
+  private_cluster_enabled          = true # default value
 
   depends_on = [module.network]
 }

--- a/README.md
+++ b/README.md
@@ -48,16 +48,16 @@ module "aks" {
   rbac_aad_admin_group_object_ids  = [data.azuread_group.aks_cluster_admins.id]
   rbac_aad_managed                 = true
   private_cluster_enabled          = true # default value
-  enable_http_application_routing = true
-  enable_azure_policy             = true  
+  enable_http_application_routing  = true
+  enable_azure_policy              = true
   enable_auto_scaling              = true
   agents_min_count                 = 1
   agents_max_count                 = 2
   agents_count                     = null # Please set `agents_count` `null` while `enable_auto_scaling` is `true` to avoid possible `agents_count` changes.
-  agents_max_pods                 = 100
-  agents_pool_name                = "defaultnodepool"
-  agents_availability_zones       = ["1", "2"]
-  agents_type                     = "VirtualMachineScaleSets"
+  agents_max_pods                  = 100
+  agents_pool_name                 = "defaultnodepool"
+  agents_availability_zones        = ["1", "2"]
+  agents_type                      = "VirtualMachineScaleSets"
 
   agents_labels = {
     "nodepool" : "defaultnodepool"

--- a/README.md
+++ b/README.md
@@ -41,13 +41,12 @@ module "aks" {
   network_plugin                   = "azure"
   vnet_subnet_id                   = module.network.vnet_subnets[0]
   os_disk_size_gb                  = 50
-  enable_kube_dashboard            = true
-  enable_azure_policy              = true
   sku_tier                         = "Paid" # defaults to Free
   enable_role_based_access_control = true
   rbac_aad_admin_group_object_ids  = [data.azuread_group.aks_cluster_admins.id]
   rbac_aad_managed                 = true
   private_cluster_enabled          = true # default value
+  enable_kube_dashboard            = true
   enable_http_application_routing  = true
   enable_azure_policy              = true
   enable_auto_scaling              = true

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ resource "azurerm_kubernetes_cluster" "main" {
 
   default_node_pool {
     orchestrator_version  = var.orchestrator_version == null ? var.kubernetes_version : var.orchestrator_version
-    name                  = var.agents_name
+    name                  = var.agents_pool_name
     node_count            = var.agents_count
     vm_size               = var.agents_size
     os_disk_size_gb       = var.os_disk_size_gb

--- a/main.tf
+++ b/main.tf
@@ -111,10 +111,10 @@ resource "azurerm_kubernetes_cluster" "main" {
   network_profile {
     network_plugin     = var.network_plugin
     network_policy     = var.network_policy
-    dns_service_ip     = var.network_profile_dns_service_ip
-    docker_bridge_cidr = var.network_profile_docker_bridge_cidr
-    service_cidr       = var.network_profile_service_cidr
-    outbound_type      = var.network_profile_outbound_type
+    dns_service_ip     = var.net_profile_dns_service_ip
+    docker_bridge_cidr = var.net_profile_docker_bridge_cidr
+    service_cidr       = var.net_profile_service_cidr
+    outbound_type      = var.net_profile_outbound_type
   }
 
   tags = var.tags

--- a/main.tf
+++ b/main.tf
@@ -115,6 +115,8 @@ resource "azurerm_kubernetes_cluster" "main" {
     docker_bridge_cidr = var.net_profile_docker_bridge_cidr
     service_cidr       = var.net_profile_service_cidr
     outbound_type      = var.net_profile_outbound_type
+    pod_cidr           = var.net_profile_pod_cidr
+    service_cidr       = var.net_profile_service_cidr
   }
 
   tags = var.tags

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,8 @@ module "ssh-key" {
 }
 
 resource "azurerm_kubernetes_cluster" "main" {
-  name                    = "${var.prefix}-aks"
+  name                    = var.prefix
+  kubernetes_version      = var.kubernetes_version
   location                = data.azurerm_resource_group.main.location
   resource_group_name     = data.azurerm_resource_group.main.name
   dns_prefix              = var.prefix
@@ -25,15 +26,21 @@ resource "azurerm_kubernetes_cluster" "main" {
   }
 
   default_node_pool {
-    orchestrator_version = var.orchestrator_version
-    name                 = "nodepool"
-    node_count           = var.agents_count
-    vm_size              = var.agents_size
-    os_disk_size_gb      = var.os_disk_size_gb
-    vnet_subnet_id       = var.vnet_subnet_id
-    enable_auto_scaling  = var.enable_auto_scaling
-    max_count            = var.enable_auto_scaling ? var.agents_max_count : null
-    min_count            = var.enable_auto_scaling ? var.agents_min_count : null
+    orchestrator_version  = var.orchestrator_version == null ? var.kubernetes_version : var.orchestrator_version
+    name                  = var.agents_name
+    node_count            = var.agents_count
+    vm_size               = var.agents_size
+    os_disk_size_gb       = var.os_disk_size_gb
+    vnet_subnet_id        = var.vnet_subnet_id
+    enable_auto_scaling   = var.enable_auto_scaling
+    max_count             = var.enable_auto_scaling ? var.agents_max_count : null
+    min_count             = var.enable_auto_scaling ? var.agents_min_count : null
+    enable_node_public_ip = var.agents_enable_node_public_ip
+    availability_zones    = var.agents_availability_zones
+    node_labels           = var.agents_labels
+    type                  = var.agents_type
+    tags                  = merge(var.tags, var.agents_tags)
+    max_pods              = var.agents_max_pods
   }
 
   dynamic "service_principal" {
@@ -102,7 +109,12 @@ resource "azurerm_kubernetes_cluster" "main" {
   }
 
   network_profile {
-    network_plugin = var.network_plugin
+    network_plugin     = var.network_plugin
+    network_policy     = var.network_policy
+    dns_service_ip     = var.network_profile_dns_service_ip
+    docker_bridge_cidr = var.network_profile_docker_bridge_cidr
+    service_cidr       = var.network_profile_service_cidr
+    outbound_type      = var.network_profile_outbound_type
   }
 
   tags = var.tags

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "azurerm_kubernetes_cluster" "main" {
     enable_auto_scaling   = var.enable_auto_scaling
     max_count             = var.enable_auto_scaling ? var.agents_max_count : null
     min_count             = var.enable_auto_scaling ? var.agents_min_count : null
-    enable_node_public_ip = var.agents_enable_node_public_ip
+    enable_node_public_ip = var.enable_node_public_ip
     availability_zones    = var.agents_availability_zones
     node_labels           = var.agents_labels
     type                  = var.agents_type

--- a/main.tf
+++ b/main.tf
@@ -25,14 +25,15 @@ resource "azurerm_kubernetes_cluster" "main" {
   }
 
   default_node_pool {
-    name            = "nodepool"
-    node_count      = var.agents_count
-    vm_size         = var.agents_size
-    os_disk_size_gb = var.os_disk_size_gb
-    vnet_subnet_id  = var.vnet_subnet_id
+    orchestrator_version = var.orchestrator_version
+    name                 = "nodepool"
+    node_count           = var.agents_count
+    vm_size              = var.agents_size
+    os_disk_size_gb      = var.os_disk_size_gb
+    vnet_subnet_id       = var.vnet_subnet_id
   }
 
-  dynamic service_principal {
+  dynamic "service_principal" {
     for_each = var.client_id != "" && var.client_secret != "" ? ["service_principal"] : []
     content {
       client_id     = var.client_id
@@ -40,7 +41,7 @@ resource "azurerm_kubernetes_cluster" "main" {
     }
   }
 
-  dynamic identity {
+  dynamic "identity" {
     for_each = var.client_id == "" || var.client_secret == "" ? ["identity"] : []
     content {
       type = "SystemAssigned"
@@ -52,21 +53,21 @@ resource "azurerm_kubernetes_cluster" "main" {
       enabled = var.enable_http_application_routing
     }
 
-    dynamic kube_dashboard {
+    dynamic "kube_dashboard" {
       for_each = var.enable_kube_dashboard != null ? ["kube_dashboard"] : []
       content {
         enabled = var.enable_kube_dashboard
       }
     }
 
-    dynamic azure_policy {
+    dynamic "azure_policy" {
       for_each = var.enable_azure_policy ? ["azure_policy"] : []
       content {
         enabled = true
       }
     }
 
-    dynamic oms_agent {
+    dynamic "oms_agent" {
       for_each = var.enable_log_analytics_workspace ? ["log_analytics"] : []
       content {
         enabled                    = true
@@ -78,7 +79,7 @@ resource "azurerm_kubernetes_cluster" "main" {
   role_based_access_control {
     enabled = var.enable_role_based_access_control
 
-    dynamic azure_active_directory {
+    dynamic "azure_active_directory" {
       for_each = var.enable_role_based_access_control && var.rbac_aad_managed ? ["rbac"] : []
       content {
         managed                = true
@@ -86,7 +87,7 @@ resource "azurerm_kubernetes_cluster" "main" {
       }
     }
 
-    dynamic azure_active_directory {
+    dynamic "azure_active_directory" {
       for_each = var.enable_role_based_access_control && ! var.rbac_aad_managed ? ["rbac"] : []
       content {
         managed           = false

--- a/main.tf
+++ b/main.tf
@@ -8,11 +8,11 @@ module "ssh-key" {
 }
 
 resource "azurerm_kubernetes_cluster" "main" {
-  name                    = "${var.prefix}-aks"
+  name                    = var.cluster_name == null ? "${var.prefix}-aks" : var.cluster_name
   kubernetes_version      = var.kubernetes_version
   location                = data.azurerm_resource_group.main.location
   resource_group_name     = data.azurerm_resource_group.main.name
-  dns_prefix              = var.prefix
+  dns_prefix              = var.cluster_name == null ? var.prefix : var.cluster_name
   sku_tier                = var.sku_tier
   private_cluster_enabled = var.private_cluster_enabled
 
@@ -124,7 +124,7 @@ resource "azurerm_kubernetes_cluster" "main" {
 
 resource "azurerm_log_analytics_workspace" "main" {
   count               = var.enable_log_analytics_workspace ? 1 : 0
-  name                = "${var.prefix}-workspace"
+  name                = var.cluster_name == null ? "${var.prefix}-workspace" : var.cluster_name
   location            = data.azurerm_resource_group.main.location
   resource_group_name = var.resource_group_name
   sku                 = var.log_analytics_workspace_sku

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ module "ssh-key" {
 }
 
 resource "azurerm_kubernetes_cluster" "main" {
-  name                    = var.prefix
+  name                    = "${var.prefix}-aks"
   kubernetes_version      = var.kubernetes_version
   location                = data.azurerm_resource_group.main.location
   resource_group_name     = data.azurerm_resource_group.main.name
@@ -26,7 +26,7 @@ resource "azurerm_kubernetes_cluster" "main" {
   }
 
   default_node_pool {
-    orchestrator_version  = var.orchestrator_version == null ? var.kubernetes_version : var.orchestrator_version
+    orchestrator_version  = var.orchestrator_version
     name                  = var.agents_pool_name
     node_count            = var.agents_count
     vm_size               = var.agents_size

--- a/main.tf
+++ b/main.tf
@@ -98,7 +98,7 @@ resource "azurerm_kubernetes_cluster" "main" {
     }
 
     dynamic "azure_active_directory" {
-      for_each = var.enable_role_based_access_control && ! var.rbac_aad_managed ? ["rbac"] : []
+      for_each = var.enable_role_based_access_control && !var.rbac_aad_managed ? ["rbac"] : []
       content {
         managed           = false
         client_app_id     = var.rbac_aad_client_app_id

--- a/main.tf
+++ b/main.tf
@@ -8,11 +8,12 @@ module "ssh-key" {
 }
 
 resource "azurerm_kubernetes_cluster" "main" {
-  name                = "${var.prefix}-aks"
-  location            = data.azurerm_resource_group.main.location
-  resource_group_name = data.azurerm_resource_group.main.name
-  dns_prefix          = var.prefix
-  sku_tier            = var.sku_tier
+  name                    = "${var.prefix}-aks"
+  location                = data.azurerm_resource_group.main.location
+  resource_group_name     = data.azurerm_resource_group.main.name
+  dns_prefix              = var.prefix
+  sku_tier                = var.sku_tier
+  private_cluster_enabled = var.private_cluster_enabled
 
   linux_profile {
     admin_username = var.admin_username

--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,6 @@ resource "azurerm_kubernetes_cluster" "main" {
     network_policy     = var.network_policy
     dns_service_ip     = var.net_profile_dns_service_ip
     docker_bridge_cidr = var.net_profile_docker_bridge_cidr
-    service_cidr       = var.net_profile_service_cidr
     outbound_type      = var.net_profile_outbound_type
     pod_cidr           = var.net_profile_pod_cidr
     service_cidr       = var.net_profile_service_cidr

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,9 @@ resource "azurerm_kubernetes_cluster" "main" {
     vm_size              = var.agents_size
     os_disk_size_gb      = var.os_disk_size_gb
     vnet_subnet_id       = var.vnet_subnet_id
+    enable_auto_scaling  = var.enable_auto_scaling
+    max_count            = var.enable_auto_scaling ? var.agents_max_count : null
+    min_count            = var.enable_auto_scaling ? var.agents_min_count : null
   }
 
   dynamic "service_principal" {

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -40,7 +40,12 @@ module "aks" {
   sku_tier                        = "Paid"
   enable_kube_dashboard           = true
   private_cluster_enabled         = true
-  depends_on                      = [azurerm_resource_group.main]
+  enable_auto_scaling             = true
+  agents_min_count                = 1
+  agents_max_count                = 2
+  agents_count                    = null
+
+  depends_on = [azurerm_resource_group.main]
 }
 
 module "aks_without_monitor" {

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -38,12 +38,28 @@ module "aks" {
   enable_http_application_routing = true
   enable_azure_policy             = true
   sku_tier                        = "Paid"
-  enable_kube_dashboard           = true
   private_cluster_enabled         = true
   enable_auto_scaling             = true
   agents_min_count                = 1
   agents_max_count                = 2
   agents_count                    = null
+  agents_max_pods                 = 100
+  agents_pool_name                = "testnodepool"
+  agents_availability_zones       = ["1", "2"]
+  agents_type                     = "VirtualMachineScaleSets"
+
+  agents_labels = {
+    "node1" : "label1"
+  }
+
+  agents_tags = {
+    "Agent" : "agentTag"
+  }
+
+  network_policy                 = "azure"
+  net_profile_dns_service_ip     = "10.0.0.10"
+  net_profile_docker_bridge_cidr = "170.10.0.1/16"
+  net_profile_service_cidr       = "10.0.0.0/16"
 
   depends_on = [azurerm_resource_group.main]
 }
@@ -53,36 +69,7 @@ module "aks_without_monitor" {
   prefix                         = "prefix2-${random_id.prefix.hex}"
   resource_group_name            = azurerm_resource_group.main.name
   enable_log_analytics_workspace = false
+  enable_kube_dashboard          = false
+  net_profile_pod_cidr           = "10.1.0.0/16"
   depends_on                     = [azurerm_resource_group.main]
-}
-
-module "aks_network_profile_config" {
-  source                          = "../.."
-  prefix                          = "prefix-${random_id.prefix.hex}"
-  resource_group_name             = azurerm_resource_group.main.name
-  client_id                       = var.client_id
-  client_secret                   = var.client_secret
-  kubernetes_version              = "1.19.3"
-  orchestrator_version            = "1.19.3"
-  network_plugin                  = "azure"
-  vnet_subnet_id                  = azurerm_subnet.test.id
-  os_disk_size_gb                 = 60
-  enable_http_application_routing = true
-  enable_azure_policy             = true
-  sku_tier                        = "Paid"
-  enable_kube_dashboard           = true
-  private_cluster_enabled         = true
-  enable_node_public_ip           = false
-  enable_auto_scaling             = true
-  agents_min_count                = 1
-  agents_max_count                = 2
-  agents_max_pods                 = 100
-  network_plugin                  = "azure"
-  network_policy                  = "azure"
-  net_profile_docker_bridge_cidr  = "170.10.0.1/16"
-  net_profile_service_cidr        = "10.0.0.0/16"
-  net_profile_dns_service_ip      = "10.0.0.10"
-
-  
-  depends_on = [azurerm_resource_group.main]
 }

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -81,6 +81,6 @@ module "aks_network_profile_config" {
   net_profile_docker_bridge_cidr  = "170.10.0.1/16"
   net_profile_service_cidr        = "10.0.0.0/16"
   net_profile_dns_service_ip      = "10.0.0.10"
-
+  
   depends_on = [azurerm_resource_group.main]
 }

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -24,12 +24,14 @@ resource "azurerm_subnet" "test" {
   address_prefixes     = ["10.52.0.0/24"]
 }
 
-module aks {
+module "aks" {
   source                          = "../.."
   prefix                          = "prefix-${random_id.prefix.hex}"
   resource_group_name             = azurerm_resource_group.main.name
   client_id                       = var.client_id
   client_secret                   = var.client_secret
+  kubernetes_version              = "1.19.3"
+  orchestrator_version            = "1.19.3"
   network_plugin                  = "azure"
   vnet_subnet_id                  = azurerm_subnet.test.id
   os_disk_size_gb                 = 60
@@ -41,7 +43,7 @@ module aks {
   depends_on                      = [azurerm_resource_group.main]
 }
 
-module aks_without_monitor {
+module "aks_without_monitor" {
   source                         = "../.."
   prefix                         = "prefix2-${random_id.prefix.hex}"
   resource_group_name            = azurerm_resource_group.main.name

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -56,7 +56,7 @@ module "aks_without_monitor" {
   depends_on                     = [azurerm_resource_group.main]
 }
 
-module "aks" {
+module "aks_network_profile_config" {
   source                          = "../.."
   prefix                          = "prefix-${random_id.prefix.hex}"
   resource_group_name             = azurerm_resource_group.main.name

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -55,3 +55,32 @@ module "aks_without_monitor" {
   enable_log_analytics_workspace = false
   depends_on                     = [azurerm_resource_group.main]
 }
+
+module "aks" {
+  source                          = "../.."
+  prefix                          = "prefix-${random_id.prefix.hex}"
+  resource_group_name             = azurerm_resource_group.main.name
+  client_id                       = var.client_id
+  client_secret                   = var.client_secret
+  kubernetes_version              = "1.19.3"
+  orchestrator_version            = "1.19.3"
+  network_plugin                  = "azure"
+  vnet_subnet_id                  = azurerm_subnet.test.id
+  os_disk_size_gb                 = 60
+  enable_http_application_routing = true
+  enable_azure_policy             = true
+  sku_tier                        = "Paid"
+  enable_kube_dashboard           = true
+  private_cluster_enabled         = true
+  enable_auto_scaling             = true
+  agents_min_count                = 1
+  agents_max_count                = 2
+  agents_max_pods                 = 100
+  network_plugin                  = "azure"
+  network_policy                  = "azure"
+  net_profile_docker_bridge_cidr  = "170.10.0.1/16"
+  net_profile_service_cidr        = "10.0.0.0/16"
+  net_profile_dns_service_ip      = "10.0.0.10"
+
+  depends_on = [azurerm_resource_group.main]
+}

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -72,6 +72,7 @@ module "aks_network_profile_config" {
   sku_tier                        = "Paid"
   enable_kube_dashboard           = true
   private_cluster_enabled         = true
+  enable_node_public_ip           = false
   enable_auto_scaling             = true
   agents_min_count                = 1
   agents_max_count                = 2
@@ -81,6 +82,7 @@ module "aks_network_profile_config" {
   net_profile_docker_bridge_cidr  = "170.10.0.1/16"
   net_profile_service_cidr        = "10.0.0.0/16"
   net_profile_dns_service_ip      = "10.0.0.10"
+
   
   depends_on = [azurerm_resource_group.main]
 }

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -37,6 +37,7 @@ module aks {
   enable_azure_policy             = true
   sku_tier                        = "Paid"
   enable_kube_dashboard           = true
+  private_cluster_enabled         = true
   depends_on                      = [azurerm_resource_group.main]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -152,6 +152,30 @@ variable "network_plugin" {
   default     = "kubenet"
 }
 
+variable "network_policy" {
+  description = " (Optional) Sets up network policy to be used with Azure CNI. Network policy allows us to control the traffic flow between pods. Currently supported values are calico and azure. Changing this forces a new resource to be created."
+  type        = string
+  default     = "calico"
+}
+
+variable "net_profile_dns_service_ip" {
+  description = "(Optional) IP address within the Kubernetes service address range that will be used by cluster service discovery (kube-dns). Changing this forces a new resource to be created."
+  type        = string
+  default     = null
+}
+
+variable "net_profile_docker_bridge_cidr" {
+  description = "(Optional) IP address (in CIDR notation) used as the Docker bridge IP address on nodes. Changing this forces a new resource to be created."
+  type        = string
+  default     = null
+}
+
+variable "net_profile_outbound_type" {
+  description = "(Optional) The outbound (egress) routing method which should be used for this Kubernetes Cluster. Possible values are loadBalancer and userDefinedRouting. Defaults to loadBalancer."
+  type        = string
+  default     = "loadBalancer"
+}
+
 variable "kubernetes_version" {
   description = "Specify which Kubernetes release to use. The default used is the latest Kubernetes version available in the region"
   type        = string
@@ -180,4 +204,46 @@ variable "agents_min_count" {
   type        = number
   description = "Minimum number of nodes in a pool"
   default     = null
+}
+
+variable "agents_name" {
+  description = "The default Azure AKS agentpool (nodepool) name."
+  type        = string
+  default     = "nodepool"
+}
+
+variable "agents_enable_node_public_ip" {
+  description = "(Optional) Should nodes in this Node Pool have a Public IP Address? Defaults to false."
+  type        = bool
+  default     = false
+}
+
+variable "agents_availability_zones" {
+  description = "(Optional) A list of Availability Zones across which the Node Pool should be spread. Changing this forces a new resource to be created."
+  type        = list(string)
+  default     = []
+}
+
+variable "agents_labels" {
+  description = "(Optional) A map of Kubernetes labels which should be applied to nodes in the Default Node Pool. Changing this forces a new resource to be created."
+  type        = map(string)
+  default     = {}
+}
+
+variable "agents_type" {
+  description = "(Optional) The type of Node Pool which should be created. Possible values are AvailabilitySet and VirtualMachineScaleSets. Defaults to VirtualMachineScaleSets."
+  type        = string
+  default     = "VirtualMachineScaleSets"
+}
+
+variable "agents_tags" {
+  description = "(Optional) A mapping of tags to assign to the Node Pool."
+  type        = map(string)
+  default     = {}
+}
+
+variable "agents_max_pods" {
+  description = "(Optional) The maximum number of pods that can run on each agent. Changing this forces a new resource to be created."
+  type        = number
+  default     = 250
 }

--- a/variables.tf
+++ b/variables.tf
@@ -206,7 +206,7 @@ variable "agents_min_count" {
   default     = null
 }
 
-variable "agents_name" {
+variable "agents_pool_name" {
   description = "The default Azure AKS agentpool (nodepool) name."
   type        = string
   default     = "nodepool"

--- a/variables.tf
+++ b/variables.tf
@@ -80,6 +80,12 @@ variable "os_disk_size_gb" {
   default     = 50
 }
 
+variable "private_cluster_enabled" {
+  description = "If true cluster API server will be exposed only on internal IP address and available only in cluster vnet."
+  type        = bool
+  default     = false
+}
+
 variable "enable_kube_dashboard" {
   description = "Enable Kubernetes Dashboard."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,7 @@ variable "log_retention_in_days" {
 }
 
 variable "agents_count" {
-  description = "The number of Agents that should exist in the Agent Pool"
+  description = "The number of Agents that should exist in the Agent Pool. Please set `agents_count` `null` while `enable_auto_scaling` is `true` to avoid possible `agents_count` changes."
   type        = number
   default     = 2
 }
@@ -161,5 +161,23 @@ variable "kubernetes_version" {
 variable "orchestrator_version" {
   description = "Specify which Kubernetes release to use for the orchestration layer. The default used is the latest Kubernetes version available in the region"
   type        = string
+  default     = null
+}
+
+variable "enable_auto_scaling" {
+  description = "Enable node pool autoscaling"
+  type        = bool
+  default     = false
+}
+
+variable "agents_max_count" {
+  type        = number
+  description = "Maximum number of nodes in a pool"
+  default     = null
+}
+
+variable "agents_min_count" {
+  type        = number
+  description = "Minimum number of nodes in a pool"
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -224,7 +224,7 @@ variable "agents_pool_name" {
   default     = "nodepool"
 }
 
-variable "agents_enable_node_public_ip" {
+variable "enable_node_public_ip" {
   description = "(Optional) Should nodes in this Node Pool have a Public IP Address? Defaults to false."
   type        = bool
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,11 @@ variable "resource_group_name" {
   type        = string
 }
 
+variable "cluster_name" {
+  description = "The name for the resources created in the specified Azure Resource Group. This variable overwrites the 'prefix' var"
+  type        = string
+}
+
 variable "prefix" {
   description = "The prefix for the resources created in the specified Azure Resource Group"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -151,3 +151,15 @@ variable "network_plugin" {
   type        = string
   default     = "kubenet"
 }
+
+variable "kubernetes_version" {
+  description = "Specify which Kubernetes release to use. The default used is the latest Kubernetes version available in the region"
+  type        = string
+  default     = null
+}
+
+variable "orchestrator_version" {
+  description = "Specify which Kubernetes release to use for the orchestration layer. The default used is the latest Kubernetes version available in the region"
+  type        = string
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -155,7 +155,7 @@ variable "network_plugin" {
 variable "network_policy" {
   description = " (Optional) Sets up network policy to be used with Azure CNI. Network policy allows us to control the traffic flow between pods. Currently supported values are calico and azure. Changing this forces a new resource to be created."
   type        = string
-  default     = "calico"
+  default     = null
 }
 
 variable "net_profile_dns_service_ip" {
@@ -233,7 +233,7 @@ variable "enable_node_public_ip" {
 variable "agents_availability_zones" {
   description = "(Optional) A list of Availability Zones across which the Node Pool should be spread. Changing this forces a new resource to be created."
   type        = list(string)
-  default     = []
+  default     = null
 }
 
 variable "agents_labels" {
@@ -257,5 +257,5 @@ variable "agents_tags" {
 variable "agents_max_pods" {
   description = "(Optional) The maximum number of pods that can run on each agent. Changing this forces a new resource to be created."
   type        = number
-  default     = 250
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -176,6 +176,18 @@ variable "net_profile_outbound_type" {
   default     = "loadBalancer"
 }
 
+variable "net_profile_pod_cidr" {
+  description = " (Optional) The CIDR to use for pod IP addresses. This field can only be set when network_plugin is set to kubenet. Changing this forces a new resource to be created."
+  type        = string
+  default     = null
+}
+
+variable "net_profile_service_cidr" {
+  description = "(Optional) The Network Range used by the Kubernetes service. Changing this forces a new resource to be created."
+  type        = string
+  default     = null
+}
+
 variable "kubernetes_version" {
   description = "Specify which Kubernetes release to use. The default used is the latest Kubernetes version available in the region"
   type        = string


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-aks .
$ docker run --rm azure-aks /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 

Changes proposed in the pull request:

This PR adds the 'cluster_name' variable that has precedence over the 'prefix' variable.
The 'cluster_name' sets the resource's names instead of applying a prefix.
