### PR TITLE
Add cluster_name variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ module "aks" {
   client_secret                    = "your-service-principal-client-password"
   kubernetes_version               = "1.19.3"
   orchestrator_version             = "1.19.3"
-  prefix                           = "prefix"
+  cluster_name                     = "cluster-name"
   network_plugin                   = "azure"
   vnet_subnet_id                   = module.network.vnet_subnets[0]
   os_disk_size_gb                  = 50

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ module "aks" {
   client_secret                    = "your-service-principal-client-password"
   kubernetes_version               = "1.19.3"
   orchestrator_version             = "1.19.3"
+  prefix                           = "prefix"
   cluster_name                     = "cluster-name"
   network_plugin                   = "azure"
   vnet_subnet_id                   = module.network.vnet_subnets[0]

--- a/main.tf
+++ b/main.tf
@@ -8,11 +8,11 @@ module "ssh-key" {
 }
 
 resource "azurerm_kubernetes_cluster" "main" {
-  name                    = "${var.prefix}-aks"
+  name                    = var.cluster_name == null ? "${var.prefix}-aks" : var.cluster_name
   kubernetes_version      = var.kubernetes_version
   location                = data.azurerm_resource_group.main.location
   resource_group_name     = data.azurerm_resource_group.main.name
-  dns_prefix              = var.prefix
+  dns_prefix              = var.cluster_name == null ? var.prefix : var.cluster_name
   sku_tier                = var.sku_tier
   private_cluster_enabled = var.private_cluster_enabled
 
@@ -124,7 +124,7 @@ resource "azurerm_kubernetes_cluster" "main" {
 
 resource "azurerm_log_analytics_workspace" "main" {
   count               = var.enable_log_analytics_workspace ? 1 : 0
-  name                = "${var.prefix}-workspace"
+  name                = var.cluster_name == null ? "${var.prefix}-workspace" : var.cluster_name
   location            = data.azurerm_resource_group.main.location
   resource_group_name = var.resource_group_name
   sku                 = var.log_analytics_workspace_sku

--- a/main.tf
+++ b/main.tf
@@ -8,11 +8,11 @@ module "ssh-key" {
 }
 
 resource "azurerm_kubernetes_cluster" "main" {
-  name                    = var.cluster_name == "" ? "${var.prefix}-aks" : var.cluster_name
+  name                    = var.cluster_name == null ? "${var.prefix}-aks" : var.cluster_name
   kubernetes_version      = var.kubernetes_version
   location                = data.azurerm_resource_group.main.location
   resource_group_name     = data.azurerm_resource_group.main.name
-  dns_prefix              = var.prefix ? var.prefix : var.cluster_name
+  dns_prefix              = var.prefix
   sku_tier                = var.sku_tier
   private_cluster_enabled = var.private_cluster_enabled
 
@@ -124,7 +124,7 @@ resource "azurerm_kubernetes_cluster" "main" {
 
 resource "azurerm_log_analytics_workspace" "main" {
   count               = var.enable_log_analytics_workspace ? 1 : 0
-  name                = var.cluster_analytics_workspace
+  name                = var.cluster_log_analytics_workspace_name == null ? "${var.prefix}-workspace" : var.cluster_log_analytics_workspace_name
   location            = data.azurerm_resource_group.main.location
   resource_group_name = var.resource_group_name
   sku                 = var.log_analytics_workspace_sku

--- a/main.tf
+++ b/main.tf
@@ -8,11 +8,11 @@ module "ssh-key" {
 }
 
 resource "azurerm_kubernetes_cluster" "main" {
-  name                    = var.cluster_name == null ? "${var.prefix}-aks" : var.cluster_name
+  name                    = var.cluster_name == "" ? "${var.prefix}-aks" : var.cluster_name
   kubernetes_version      = var.kubernetes_version
   location                = data.azurerm_resource_group.main.location
   resource_group_name     = data.azurerm_resource_group.main.name
-  dns_prefix              = var.cluster_name == null ? var.prefix : var.cluster_name
+  dns_prefix              = var.cluster_name == "" ? var.prefix : var.cluster_name
   sku_tier                = var.sku_tier
   private_cluster_enabled = var.private_cluster_enabled
 
@@ -124,7 +124,7 @@ resource "azurerm_kubernetes_cluster" "main" {
 
 resource "azurerm_log_analytics_workspace" "main" {
   count               = var.enable_log_analytics_workspace ? 1 : 0
-  name                = var.cluster_name == null ? "${var.prefix}-workspace" : var.cluster_name
+  name                = var.cluster_name == "" ? "${var.prefix}-workspace" : var.cluster_name
   location            = data.azurerm_resource_group.main.location
   resource_group_name = var.resource_group_name
   sku                 = var.log_analytics_workspace_sku

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource "azurerm_kubernetes_cluster" "main" {
   kubernetes_version      = var.kubernetes_version
   location                = data.azurerm_resource_group.main.location
   resource_group_name     = data.azurerm_resource_group.main.name
-  dns_prefix              = var.cluster_name == "" ? var.prefix : var.cluster_name
+  dns_prefix              = var.prefix ? var.prefix : var.cluster_name
   sku_tier                = var.sku_tier
   private_cluster_enabled = var.private_cluster_enabled
 
@@ -124,7 +124,7 @@ resource "azurerm_kubernetes_cluster" "main" {
 
 resource "azurerm_log_analytics_workspace" "main" {
   count               = var.enable_log_analytics_workspace ? 1 : 0
-  name                = var.cluster_name == "" ? "${var.prefix}-workspace" : var.cluster_name
+  name                = var.cluster_analytics_workspace
   location            = data.azurerm_resource_group.main.location
   resource_group_name = var.resource_group_name
   sku                 = var.log_analytics_workspace_sku

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -75,13 +75,13 @@ module "aks_without_monitor" {
 }
 
 module "aks_cluster_name" {
-  source                         = "../.."
-  cluster_name                   = "test-cluster"
-  prefix                         = "prefix"
-  resource_group_name            = azurerm_resource_group.main.name
-  enable_log_analytics_workspace = true
-  cluster_analytics_workspace    = "test-cluster"
-  enable_kube_dashboard          = false
-  net_profile_pod_cidr           = "10.1.0.0/16"
-  depends_on                     = [azurerm_resource_group.main]
+  source                               = "../.."
+  cluster_name                         = "test-cluster"
+  prefix                               = "prefix"
+  resource_group_name                  = azurerm_resource_group.main.name
+  enable_log_analytics_workspace       = true
+  cluster_log_analytics_workspace_name = "test-cluster"
+  enable_kube_dashboard                = false
+  net_profile_pod_cidr                 = "10.1.0.0/16"
+  depends_on                           = [azurerm_resource_group.main]
 }

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -77,8 +77,10 @@ module "aks_without_monitor" {
 module "aks_cluster_name" {
   source                         = "../.."
   cluster_name                   = "test-cluster"
+  prefix                         = "prefix"
   resource_group_name            = azurerm_resource_group.main.name
-  enable_log_analytics_workspace = false
+  enable_log_analytics_workspace = true
+  cluster_analytics_workspace    = "test-cluster"
   enable_kube_dashboard          = false
   net_profile_pod_cidr           = "10.1.0.0/16"
   depends_on                     = [azurerm_resource_group.main]

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -73,3 +73,13 @@ module "aks_without_monitor" {
   net_profile_pod_cidr           = "10.1.0.0/16"
   depends_on                     = [azurerm_resource_group.main]
 }
+
+module "aks_cluster_name" {
+  source                         = "../.."
+  cluster_name                   = "test-cluster"
+  resource_group_name            = azurerm_resource_group.main.name
+  enable_log_analytics_workspace = false
+  enable_kube_dashboard          = false
+  net_profile_pod_cidr           = "10.1.0.0/16"
+  depends_on                     = [azurerm_resource_group.main]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,6 @@ variable "cluster_log_analytics_workspace_name" {
 variable "prefix" {
   description = "(Required) The prefix for the resources created in the specified Azure Resource Group"
   type        = string
-  default     = null
 }
 
 variable "client_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -9,16 +9,16 @@ variable "cluster_name" {
   default     = null
 }
 
-variable "cluster_analytics_workspace" {
+variable "cluster_log_analytics_workspace_name" {
   description = "(Optional) The name of the Analytics workspace"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "prefix" {
-  description = "The prefix for the resources created in the specified Azure Resource Group"
+  description = "(Required) The prefix for the resources created in the specified Azure Resource Group"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "client_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,11 @@ variable "resource_group_name" {
   type        = string
 }
 
+variable "cluster_name" {
+  description = "(Optional) The name for the resources created in the specified Azure Resource Group. This variable overwrites the 'prefix' var"
+  type        = string
+}
+
 variable "prefix" {
   description = "The prefix for the resources created in the specified Azure Resource Group"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,13 @@ variable "resource_group_name" {
 }
 
 variable "cluster_name" {
-  description = "(Optional) The name for the resources created in the specified Azure Resource Group. This variable overwrites the 'prefix' var"
+  description = "(Optional) The name for the AKS resources created in the specified Azure Resource Group. This variable overwrites the 'prefix' var (The 'prefix' var will still be applied to the dns_prefix if it is set)"
+  type        = string
+  default     = null
+}
+
+variable "cluster_analytics_workspace" {
+  description = "(Optional) The name of the Analytics workspace"
   type        = string
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,11 +6,13 @@ variable "resource_group_name" {
 variable "cluster_name" {
   description = "(Optional) The name for the resources created in the specified Azure Resource Group. This variable overwrites the 'prefix' var"
   type        = string
+  default     = ""
 }
 
 variable "prefix" {
   description = "The prefix for the resources created in the specified Azure Resource Group"
   type        = string
+  default     = ""
 }
 
 variable "client_id" {


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-aks .
$ docker run --rm azure-aks /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 

Changes proposed in the pull request:

This PR adds the cluster_name variable.



