### PR TITLE
added suffix, fixed names to match msft recomendations, fixed names o…

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,75 +1,79 @@
 output "client_key" {
-  value = azurerm_kubernetes_cluster.main.kube_config[0].client_key
+  value = azurerm_kubernetes_cluster.this.kube_config[0].client_key
 }
 
 output "client_certificate" {
-  value = azurerm_kubernetes_cluster.main.kube_config[0].client_certificate
+  value = azurerm_kubernetes_cluster.this.kube_config[0].client_certificate
 }
 
 output "cluster_ca_certificate" {
-  value = azurerm_kubernetes_cluster.main.kube_config[0].cluster_ca_certificate
+  value = azurerm_kubernetes_cluster.this.kube_config[0].cluster_ca_certificate
+}
+
+output "kubernetes_cluster" {
+  value = azurerm_kubernetes_cluster.this
 }
 
 output "host" {
-  value = azurerm_kubernetes_cluster.main.kube_config[0].host
+  value = azurerm_kubernetes_cluster.this.kube_config[0].host
 }
 
 output "username" {
-  value = azurerm_kubernetes_cluster.main.kube_config[0].username
+  value = azurerm_kubernetes_cluster.this.kube_config[0].username
 }
 
 output "password" {
-  value = azurerm_kubernetes_cluster.main.kube_config[0].password
+  value = azurerm_kubernetes_cluster.this.kube_config[0].password
 }
 
 output "node_resource_group" {
-  value = azurerm_kubernetes_cluster.main.node_resource_group
+  value = azurerm_kubernetes_cluster.this.node_resource_group
 }
 
 output "location" {
-  value = azurerm_kubernetes_cluster.main.location
+  value = azurerm_kubernetes_cluster.this.location
 }
 
 output "aks_id" {
-  value = azurerm_kubernetes_cluster.main.id
+  value = azurerm_kubernetes_cluster.this.id
 }
 
 output "kube_config_raw" {
-  value = azurerm_kubernetes_cluster.main.kube_config_raw
+  value = azurerm_kubernetes_cluster.this.kube_config_raw
 }
 
 output "http_application_routing_zone_name" {
-  value = length(azurerm_kubernetes_cluster.main.addon_profile) > 0 && length(azurerm_kubernetes_cluster.main.addon_profile[0].http_application_routing) > 0 ? azurerm_kubernetes_cluster.main.addon_profile[0].http_application_routing[0].http_application_routing_zone_name : ""
+  value = length(azurerm_kubernetes_cluster.this.addon_profile) > 0 && length(azurerm_kubernetes_cluster.this.addon_profile[0].http_application_routing) > 0 ? azurerm_kubernetes_cluster.this.addon_profile[0].http_application_routing[0].http_application_routing_zone_name : ""
 }
 
 output "system_assigned_identity" {
-  value = azurerm_kubernetes_cluster.main.identity
+  value = azurerm_kubernetes_cluster.this.identity
 }
 
 output "kubelet_identity" {
-  value = azurerm_kubernetes_cluster.main.kubelet_identity
+  value = azurerm_kubernetes_cluster.this.kubelet_identity
 }
 
 output "admin_client_key" {
-  value = length(azurerm_kubernetes_cluster.main.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.main.kube_admin_config.0.client_key : ""
+  value = length(azurerm_kubernetes_cluster.this.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.this.kube_admin_config.0.client_key : ""
 }
 
 output "admin_client_certificate" {
-  value = length(azurerm_kubernetes_cluster.main.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.main.kube_admin_config.0.client_certificate : ""
+  value = length(azurerm_kubernetes_cluster.this.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.this.kube_admin_config.0.client_certificate : ""
 }
 
 output "admin_cluster_ca_certificate" {
-  value = length(azurerm_kubernetes_cluster.main.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.main.kube_admin_config.0.cluster_ca_certificate : ""
+  value = length(azurerm_kubernetes_cluster.this.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.this.kube_admin_config.0.cluster_ca_certificate : ""
 }
 
 output "admin_host" {
-  value = length(azurerm_kubernetes_cluster.main.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.main.kube_admin_config.0.host : ""
+  value = length(azurerm_kubernetes_cluster.this.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.this.kube_admin_config.0.host : ""
 }
 
 output "admin_username" {
-  value = length(azurerm_kubernetes_cluster.main.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.main.kube_admin_config.0.username : ""
+  value = length(azurerm_kubernetes_cluster.this.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.this.kube_admin_config.0.username : ""
 }
 
 output "admin_password" {
-  value = length(azurerm_kubernetes_cluster.main.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.main.kube_admin_config.0.password : ""
+  value = length(azurerm_kubernetes_cluster.this.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.this.kube_admin_config.0.password : ""
 }

--- a/test/fixture/prereqs.tf
+++ b/test/fixture/prereqs.tf
@@ -1,0 +1,52 @@
+// we need a network, subnet, service principal and loging workspace
+
+provider "azurerm" {
+  features {}
+}
+
+
+resource "random_id" "prefix" {
+  byte_length = 8
+}
+resource "azurerm_resource_group" "main" {
+  name     = "${random_id.prefix.hex}-rg"
+  location = var.location
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "${random_id.prefix.hex}-vn"
+  address_space       = ["10.52.0.0/16"]
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "${random_id.prefix.hex}-sn"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.52.0.0/24"]
+}
+resource "azuread_application" "this" {
+  display_name            = "${random_id.prefix.hex}-sp"
+  group_membership_claims = "All"
+}
+
+resource "azuread_service_principal" "this" {
+  application_id = azuread_application.this.application_id
+
+  provisioner "local-exec" {
+    interpreter = ["pwsh", "-Command"]
+    command     = "start-sleep 30"
+  }
+}
+
+resource "azuread_service_principal_password" "this" {
+  service_principal_id = azuread_service_principal.this.id
+  value                = random_id.prefix.hex
+  end_date             = "2099-01-01T01:02:03Z"
+
+  provisioner "local-exec" {
+    interpreter = ["pwsh", "-Command"]
+    command     = "start-sleep 30"
+  }
+}

--- a/test/fixture/variables.tf
+++ b/test/fixture/variables.tf
@@ -2,5 +2,5 @@ variable "location" {
   default = "eastus"
 }
 
-variable "client_id" {}
-variable "client_secret" {}
+# variable "client_id" {}
+# variable "client_secret" {}

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,15 @@ variable "resource_group_name" {
 variable "prefix" {
   description = "The prefix for the resources created in the specified Azure Resource Group"
   type        = string
+  default     = ""
 }
+
+variable "suffix" {
+  description = "The suffix for the resources created in the specified Azure Resource Group"
+  type        = string
+  default     = ""
+}
+
 
 variable "client_id" {
   description = "(Optional) The Client ID (appId) for the Service Principal used for the AKS deployment"
@@ -258,4 +266,23 @@ variable "agents_max_pods" {
   description = "(Optional) The maximum number of pods that can run on each agent. Changing this forces a new resource to be created."
   type        = number
   default     = null
+}
+
+variable "node_pools" {
+  default     = {}
+  description = "Map of maps for node pool objects, its a bit complex, see example in tests. "
+  // i cant work out how to do this and still make things optional ... see examples folder
+  # type = map(map(object({
+  #   vm_size             = string
+  #   node_count          = number
+  #   availability_zones  = bool
+  #   enable_auto_scaling = bool
+  #   max_count           = number
+  #   min_count           = number
+  #   max_pods            = number
+  #   node_tains          = list(string)
+  #   os_disk_size_gb     = number
+  #   os_type             = string
+  #   vnet_subnet_id      = string
+  # })))
 }


### PR DESCRIPTION
This is a big breaking change due to changing the name of the terraform resources to comply with terraform best practices.

- Renamed resources to match MSFT naming guidelines
- Added support for suffix
- Added support to add node pools

<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-aks .
$ docker run --rm azure-aks /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 

Changes proposed in the pull request:


