### PR TITLE
Fixed disabling oms-plugin

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,26 +63,17 @@ resource "azurerm_kubernetes_cluster" "main" {
       enabled = var.enable_http_application_routing
     }
 
-    dynamic "kube_dashboard" {
-      for_each = var.enable_kube_dashboard != null ? ["kube_dashboard"] : []
-      content {
-        enabled = var.enable_kube_dashboard
-      }
+    kube_dashboard {
+      enabled = var.enable_kube_dashboard
     }
 
-    dynamic "azure_policy" {
-      for_each = var.enable_azure_policy ? ["azure_policy"] : []
-      content {
-        enabled = true
-      }
+    azure_policy {
+      enabled = var.enable_azure_policy
     }
 
-    dynamic "oms_agent" {
-      for_each = var.enable_log_analytics_workspace ? ["log_analytics"] : []
-      content {
-        enabled                    = true
-        log_analytics_workspace_id = azurerm_log_analytics_workspace.main[0].id
-      }
+    oms_agent {
+      enabled                    = var.enable_log_analytics_workspace
+      log_analytics_workspace_id = var.enable_log_analytics_workspace ? azurerm_log_analytics_workspace.main[0].id : null
     }
   }
 

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -30,8 +30,8 @@ module "aks" {
   resource_group_name             = azurerm_resource_group.main.name
   client_id                       = var.client_id
   client_secret                   = var.client_secret
-  kubernetes_version              = "1.19.3"
-  orchestrator_version            = "1.19.3"
+  kubernetes_version              = "1.19.6"
+  orchestrator_version            = "1.19.6"
   network_plugin                  = "azure"
   vnet_subnet_id                  = azurerm_subnet.test.id
   os_disk_size_gb                 = 60

--- a/variables.tf
+++ b/variables.tf
@@ -89,7 +89,7 @@ variable "private_cluster_enabled" {
 variable "enable_kube_dashboard" {
   description = "Enable Kubernetes Dashboard."
   type        = bool
-  default     = null
+  default     = false
 }
 
 variable "enable_http_application_routing" {


### PR DESCRIPTION
Signed-off-by: Dmytro Oboznyi <dmytro.oboznyi@syncier.com>

<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-aks .
$ docker run --rm azure-aks /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

If you try to disable log-analytics in existing cluster with enabled oms plugin you will get such error:
```
Error: waiting for update of Managed Kubernetes Cluster "<cluster_name>" (Resource Group "<rg_name>"): Code="GetLogAnalyticsWorkspaceError" Message="Unable to get log analytics workspace info. Resource ID: /subscriptions/<subscription_id>/resourcegroups/<rg_name>/providers/microsoft.operationalinsights/workspaces/<log_analytics_workspace_id>. Details: autorest/azure: Service returned an error. Status=404 Code=\"ResourceNotFound\" Message=\"The Resource 'Microsoft.OperationalInsights/workspaces/<log_analytics_workspace_id>' under resource group '<rg_name>' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix\". For more details about how to create and use log analytics workspace,  please refer to: https://aka.ms/new-log-analytics"
```

According to the official [docs](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/container-insights-optout#create-template) in order to disable oms plugin its section shouldn't be removed completely. We should change enabled from `true` to `false` and put in workspace id `null` value. In such way you will not get an issue.

Changes proposed in the pull request:

- Changed addon profiles from dynamic fields to static
- Changed default value for `enable_kube_dashboard` from `null` to `false`

