### PR TITLE
Do not set default node pool node_count when auto scaling is enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,8 +35,8 @@ resource "azurerm_kubernetes_cluster" "main" {
       os_disk_size_gb       = var.os_disk_size_gb
       vnet_subnet_id        = var.vnet_subnet_id
       enable_auto_scaling   = var.enable_auto_scaling
-      max_count             = var.enable_auto_scaling ? var.agents_max_count : null
-      min_count             = var.enable_auto_scaling ? var.agents_min_count : null
+      max_count             = null
+      min_count             = null
       enable_node_public_ip = var.enable_node_public_ip
       availability_zones    = var.agents_availability_zones
       node_labels           = var.agents_labels
@@ -55,8 +55,8 @@ resource "azurerm_kubernetes_cluster" "main" {
       os_disk_size_gb       = var.os_disk_size_gb
       vnet_subnet_id        = var.vnet_subnet_id
       enable_auto_scaling   = var.enable_auto_scaling
-      max_count             = var.enable_auto_scaling ? var.agents_max_count : null
-      min_count             = var.enable_auto_scaling ? var.agents_min_count : null
+      max_count             = var.agents_max_count
+      min_count             = var.agents_min_count
       enable_node_public_ip = var.enable_node_public_ip
       availability_zones    = var.agents_availability_zones
       node_labels           = var.agents_labels

--- a/main.tf
+++ b/main.tf
@@ -25,22 +25,45 @@ resource "azurerm_kubernetes_cluster" "main" {
     }
   }
 
-  default_node_pool {
-    orchestrator_version  = var.orchestrator_version
-    name                  = var.agents_pool_name
-    node_count            = var.agents_count
-    vm_size               = var.agents_size
-    os_disk_size_gb       = var.os_disk_size_gb
-    vnet_subnet_id        = var.vnet_subnet_id
-    enable_auto_scaling   = var.enable_auto_scaling
-    max_count             = var.enable_auto_scaling ? var.agents_max_count : null
-    min_count             = var.enable_auto_scaling ? var.agents_min_count : null
-    enable_node_public_ip = var.enable_node_public_ip
-    availability_zones    = var.agents_availability_zones
-    node_labels           = var.agents_labels
-    type                  = var.agents_type
-    tags                  = merge(var.tags, var.agents_tags)
-    max_pods              = var.agents_max_pods
+  dynamic "default_node_pool" {
+    for_each = var.enable_auto_scaling == true ? [] : ["default_node_pool_manually_scaled"]
+    content {
+      orchestrator_version  = var.orchestrator_version
+      name                  = var.agents_pool_name
+      node_count            = var.agents_count
+      vm_size               = var.agents_size
+      os_disk_size_gb       = var.os_disk_size_gb
+      vnet_subnet_id        = var.vnet_subnet_id
+      enable_auto_scaling   = var.enable_auto_scaling
+      max_count             = var.enable_auto_scaling ? var.agents_max_count : null
+      min_count             = var.enable_auto_scaling ? var.agents_min_count : null
+      enable_node_public_ip = var.enable_node_public_ip
+      availability_zones    = var.agents_availability_zones
+      node_labels           = var.agents_labels
+      type                  = var.agents_type
+      tags                  = merge(var.tags, var.agents_tags)
+      max_pods              = var.agents_max_pods
+    }
+  }
+
+  dynamic "default_node_pool" {
+    for_each = var.enable_auto_scaling == true ? ["default_node_pool_auto_scaled"] : []
+    content {
+      orchestrator_version  = var.orchestrator_version
+      name                  = var.agents_pool_name
+      vm_size               = var.agents_size
+      os_disk_size_gb       = var.os_disk_size_gb
+      vnet_subnet_id        = var.vnet_subnet_id
+      enable_auto_scaling   = var.enable_auto_scaling
+      max_count             = var.enable_auto_scaling ? var.agents_max_count : null
+      min_count             = var.enable_auto_scaling ? var.agents_min_count : null
+      enable_node_public_ip = var.enable_node_public_ip
+      availability_zones    = var.agents_availability_zones
+      node_labels           = var.agents_labels
+      type                  = var.agents_type
+      tags                  = merge(var.tags, var.agents_tags)
+      max_pods              = var.agents_max_pods
+    }
   }
 
   dynamic "service_principal" {


### PR DESCRIPTION
**Changes proposed in the pull request**

To make the `default_node_pool` nested block `dynamic`, with content based on value of `enable_auto_scaling` input variable. In example, the `node_count` parameter of `default_node_pool` should be set only when autoscaling is disabled.
Tests pass.

Fixes #91  
