### PR TITLE
Mark kube_config_raw output as non-sensitive.

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -35,7 +35,7 @@ output "aks_id" {
 }
 
 output "kube_config_raw" {
-  value = azurerm_kubernetes_cluster.main.kube_config_raw
+  value = nonsensitive(azurerm_kubernetes_cluster.main.kube_config_raw)
 }
 
 output "http_application_routing_zone_name" {


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-aks .
$ docker run --rm azure-aks /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->
Fixes #94 
Mark kube_config_raw output as non-sensitive.
`kube_config_raw` needs to be marked as nonsensitive to work with terraform v0.15
