### PR TITLE
Add support for default pool host-based encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ module "aks" {
   enable_http_application_routing  = true
   enable_azure_policy              = true
   enable_auto_scaling              = true
+  enable_host_encryption           = true
   agents_min_count                 = 1
   agents_max_count                 = 2
   agents_count                     = null # Please set `agents_count` `null` while `enable_auto_scaling` is `true` to avoid possible `agents_count` changes.

--- a/main.tf
+++ b/main.tf
@@ -28,41 +28,43 @@ resource "azurerm_kubernetes_cluster" "main" {
   dynamic "default_node_pool" {
     for_each = var.enable_auto_scaling == true ? [] : ["default_node_pool_manually_scaled"]
     content {
-      orchestrator_version  = var.orchestrator_version
-      name                  = var.agents_pool_name
-      node_count            = var.agents_count
-      vm_size               = var.agents_size
-      os_disk_size_gb       = var.os_disk_size_gb
-      vnet_subnet_id        = var.vnet_subnet_id
-      enable_auto_scaling   = var.enable_auto_scaling
-      max_count             = null
-      min_count             = null
-      enable_node_public_ip = var.enable_node_public_ip
-      availability_zones    = var.agents_availability_zones
-      node_labels           = var.agents_labels
-      type                  = var.agents_type
-      tags                  = merge(var.tags, var.agents_tags)
-      max_pods              = var.agents_max_pods
+      orchestrator_version   = var.orchestrator_version
+      name                   = var.agents_pool_name
+      node_count             = var.agents_count
+      vm_size                = var.agents_size
+      os_disk_size_gb        = var.os_disk_size_gb
+      vnet_subnet_id         = var.vnet_subnet_id
+      enable_auto_scaling    = var.enable_auto_scaling
+      max_count              = null
+      min_count              = null
+      enable_node_public_ip  = var.enable_node_public_ip
+      availability_zones     = var.agents_availability_zones
+      node_labels            = var.agents_labels
+      type                   = var.agents_type
+      tags                   = merge(var.tags, var.agents_tags)
+      max_pods               = var.agents_max_pods
+      enable_host_encryption = var.enable_host_encryption
     }
   }
 
   dynamic "default_node_pool" {
     for_each = var.enable_auto_scaling == true ? ["default_node_pool_auto_scaled"] : []
     content {
-      orchestrator_version  = var.orchestrator_version
-      name                  = var.agents_pool_name
-      vm_size               = var.agents_size
-      os_disk_size_gb       = var.os_disk_size_gb
-      vnet_subnet_id        = var.vnet_subnet_id
-      enable_auto_scaling   = var.enable_auto_scaling
-      max_count             = var.agents_max_count
-      min_count             = var.agents_min_count
-      enable_node_public_ip = var.enable_node_public_ip
-      availability_zones    = var.agents_availability_zones
-      node_labels           = var.agents_labels
-      type                  = var.agents_type
-      tags                  = merge(var.tags, var.agents_tags)
-      max_pods              = var.agents_max_pods
+      orchestrator_version   = var.orchestrator_version
+      name                   = var.agents_pool_name
+      vm_size                = var.agents_size
+      os_disk_size_gb        = var.os_disk_size_gb
+      vnet_subnet_id         = var.vnet_subnet_id
+      enable_auto_scaling    = var.enable_auto_scaling
+      max_count              = var.agents_max_count
+      min_count              = var.agents_min_count
+      enable_node_public_ip  = var.enable_node_public_ip
+      availability_zones     = var.agents_availability_zones
+      node_labels            = var.agents_labels
+      type                   = var.agents_type
+      tags                   = merge(var.tags, var.agents_tags)
+      max_pods               = var.agents_max_pods
+      enable_host_encryption = var.enable_host_encryption
     }
   }
 
@@ -113,7 +115,7 @@ resource "azurerm_kubernetes_cluster" "main" {
     }
 
     dynamic "azure_active_directory" {
-      for_each = var.enable_role_based_access_control && ! var.rbac_aad_managed ? ["rbac"] : []
+      for_each = var.enable_role_based_access_control && !var.rbac_aad_managed ? ["rbac"] : []
       content {
         managed           = false
         client_app_id     = var.rbac_aad_client_app_id

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -41,6 +41,7 @@ module "aks" {
   os_disk_size_gb                 = 60
   enable_http_application_routing = true
   enable_azure_policy             = true
+  enable_host_encryption          = true
   sku_tier                        = "Paid"
   private_cluster_enabled         = true
   enable_auto_scaling             = true

--- a/variables.tf
+++ b/variables.tf
@@ -283,3 +283,9 @@ variable "user_assigned_identity_id" {
   type        = string
   default     = null
 }
+
+variable "enable_host_encryption" {
+  description = "Enable Host Encryption for default node pool. Encryption at host feature must be enabled on the subscription: https://docs.microsoft.com/azure/virtual-machines/linux/disks-enable-host-based-encryption-cli"
+  type        = bool
+  default     = false
+}

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.34"
+      version = "~> 2.46"
     }
   }
 


### PR DESCRIPTION
This PR adds support for default pool [host-based encryption](https://docs.microsoft.com/en-us/azure/aks/enable-host-encryption).

* there is a new `enable_host_encryption` variable, that default to `false` and can be turned to `true` to enable host-based encryption
* the documentation has been updated with this new flag
* the tests have been updated with this new flag
* the minimum AzureRM provider version has been moved to `2.46` which corresponds to the release of this property in the provider


