### PR TITLE
Replace data source lookup for "azurerm_resource_group" with variables to avoid resources recreation issue when re-applying the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ data "azuread_group" "aks_cluster_admins" {
 
 module "aks" {
   source                           = "Azure/aks/azurerm"
+  location                         = "eastus"
   resource_group_name              = azurerm_resource_group.example.name
   client_id                        = "your-service-principal-client-appid"
   client_secret                    = "your-service-principal-client-password"
@@ -91,6 +92,7 @@ resource "azurerm_resource_group" "example" {
 module "aks" {
   source              = "Azure/aks/azurerm"
   resource_group_name = azurerm_resource_group.example.name
+  location            = "eastus"
   prefix              = "prefix"
 }
 ```

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-data "azurerm_resource_group" "main" {
-  name = var.resource_group_name
-}
-
 module "ssh-key" {
   source         = "./modules/ssh-key"
   public_ssh_key = var.public_ssh_key == "" ? "" : var.public_ssh_key
@@ -10,8 +6,8 @@ module "ssh-key" {
 resource "azurerm_kubernetes_cluster" "main" {
   name                    = var.cluster_name == null ? "${var.prefix}-aks" : var.cluster_name
   kubernetes_version      = var.kubernetes_version
-  location                = data.azurerm_resource_group.main.location
-  resource_group_name     = data.azurerm_resource_group.main.name
+  location                = var.location
+  resource_group_name     = var.resource_group_name
   dns_prefix              = var.prefix
   sku_tier                = var.sku_tier
   private_cluster_enabled = var.private_cluster_enabled
@@ -142,7 +138,7 @@ resource "azurerm_kubernetes_cluster" "main" {
 resource "azurerm_log_analytics_workspace" "main" {
   count               = var.enable_log_analytics_workspace ? 1 : 0
   name                = var.cluster_log_analytics_workspace_name == null ? "${var.prefix}-workspace" : var.cluster_log_analytics_workspace_name
-  location            = data.azurerm_resource_group.main.location
+  location            = var.location
   resource_group_name = var.resource_group_name
   sku                 = var.log_analytics_workspace_sku
   retention_in_days   = var.log_retention_in_days
@@ -153,7 +149,7 @@ resource "azurerm_log_analytics_workspace" "main" {
 resource "azurerm_log_analytics_solution" "main" {
   count                 = var.enable_log_analytics_workspace ? 1 : 0
   solution_name         = "ContainerInsights"
-  location              = data.azurerm_resource_group.main.location
+  location              = var.location
   resource_group_name   = var.resource_group_name
   workspace_resource_id = azurerm_log_analytics_workspace.main[0].id
   workspace_name        = azurerm_log_analytics_workspace.main[0].name

--- a/main.tf
+++ b/main.tf
@@ -107,7 +107,6 @@ resource "azurerm_kubernetes_cluster" "main" {
       content {
         managed                = true
         admin_group_object_ids = var.rbac_aad_admin_group_object_ids
-        azure_rbac_enabled     = true
       }
     }
 

--- a/main.tf
+++ b/main.tf
@@ -107,6 +107,7 @@ resource "azurerm_kubernetes_cluster" "main" {
       content {
         managed                = true
         admin_group_object_ids = var.rbac_aad_admin_group_object_ids
+        azure_rbac_enabled     = true
       }
     }
 

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -34,6 +34,7 @@ module "aks" {
   source                          = "../.."
   prefix                          = "prefix-${random_id.prefix.hex}"
   resource_group_name             = azurerm_resource_group.main.name
+  location                        = var.location
   client_id                       = var.client_id
   client_secret                   = var.client_secret
   network_plugin                  = "azure"
@@ -73,6 +74,7 @@ module "aks_without_monitor" {
   source                         = "../.."
   prefix                         = "prefix2-${random_id.prefix.hex}"
   resource_group_name            = azurerm_resource_group.main.name
+  location                       = var.location
   enable_log_analytics_workspace = false
   enable_kube_dashboard          = false
   net_profile_pod_cidr           = "10.1.0.0/16"
@@ -84,6 +86,7 @@ module "aks_cluster_name" {
   cluster_name                         = "test-cluster"
   prefix                               = "prefix"
   resource_group_name                  = azurerm_resource_group.main.name
+  location                             = var.location
   enable_log_analytics_workspace       = true
   cluster_log_analytics_workspace_name = "test-cluster"
   enable_kube_dashboard                = false

--- a/variables.tf
+++ b/variables.tf
@@ -291,6 +291,6 @@ variable "enable_host_encryption" {
 }
 
 variable "location" {
-  description = "The Azure Region where the resources should exist. Changing this forces a new Resource Group to be created"
+  description = "The Azure Region where the resources should exist. Changing this forces a new resources to be created"
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -289,3 +289,8 @@ variable "enable_host_encryption" {
   type        = bool
   default     = false
 }
+
+variable "location" {
+  description = "The Azure Region where the resources should exist. Changing this forces a new Resource Group to be created"
+  type        = string
+}


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-aks .
$ docker run --rm azure-aks /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->
FIxes #105 
Changes proposed in the pull request:
When testing in terraform v13,14,15 - The current module results in recreation of cluster in consecutive apply due to the unwanted diff generated by data source lookup of `location` from the `resource group`. The fix in the PR proposes using variable for location in-place of a data source lookup to resolve this issue.

The data source lookup responsible:
```
 data "azurerm_resource_group" "main" {  
  name = var.resource_group_name
  }
```
Terraform plan using the module results in certain resources to `force replacement`, PFB
```
# module.aks.azurerm_kubernetes_cluster.main must be replaced
-/+ resource "azurerm_kubernetes_cluster" "main" {
      - api_server_authorized_ip_ranges = [] -> null
      - enable_pod_security_policy      = false -> null
---
      ~ location                        = "westeurope" -> (known after apply) # forces replacement
---
    }

  # module.aks.azurerm_log_analytics_solution.main[0] must be replaced
-/+ resource "azurerm_log_analytics_solution" "main" {
---
      ~ location              = "westeurope" -> (known after apply) # forces replacement
---
        }
    }

  # module.aks.azurerm_log_analytics_workspace.main[0] must be replaced
-/+ resource "azurerm_log_analytics_workspace" "main" {
 ---
      ~ location                   = "westeurope" -> (known after apply) # forces replacement
 ---
    }
```
