### PR TITLE
Added support for specifying cluster location

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ module "ssh-key" {
 resource "azurerm_kubernetes_cluster" "main" {
   name                    = var.cluster_name == null ? "${var.prefix}-aks" : var.cluster_name
   kubernetes_version      = var.kubernetes_version
-  location                = data.azurerm_resource_group.main.location
+  location                = var.location ==null ? data.azurerm_resource_group.main.location : var.location
   resource_group_name     = data.azurerm_resource_group.main.name
   dns_prefix              = var.prefix
   sku_tier                = var.sku_tier

--- a/variables.tf
+++ b/variables.tf
@@ -289,3 +289,8 @@ variable "enable_host_encryption" {
   type        = bool
   default     = false
 }
+
+variable "location" {
+  description = "Location (Region) for AKS Cluster.  If not set, will use Resource Group location"
+  type        = string
+}


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-aks .
$ docker run --rm azure-aks /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #105 

Changes proposed in the pull request:


