### PR TITLE
Enable Role Based Access Control based on Azure AD

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,6 +111,7 @@ resource "azurerm_kubernetes_cluster" "main" {
       content {
         managed                = true
         admin_group_object_ids = var.rbac_aad_admin_group_object_ids
+        azure_rbac_enabled     = true
       }
     }
 


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-aks .
$ docker run --rm azure-aks /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #103 

Changes proposed in the pull request:
When both `var.enable_role_based_access_control` & `var.rbac_aad_managed` are set to `true`, `azure_rbac_enabled` is set `true` as well

Its only possible to use `azure_rbac_enabled` when Azure Active Directory integration is Managed, meaning that Azure will create/manage the Service Principal used for integration.


