### PR TITLE
Add support for using application gateway for ingress

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,7 @@ resource "azurerm_kubernetes_cluster" "main" {
       tags                   = merge(var.tags, var.agents_tags)
       max_pods               = var.agents_max_pods
       enable_host_encryption = var.enable_host_encryption
+      os_disk_type           = var.os_disk_type
     }
   }
 
@@ -65,6 +66,7 @@ resource "azurerm_kubernetes_cluster" "main" {
       tags                   = merge(var.tags, var.agents_tags)
       max_pods               = var.agents_max_pods
       enable_host_encryption = var.enable_host_encryption
+      os_disk_type           = var.os_disk_type
     }
   }
 
@@ -85,6 +87,11 @@ resource "azurerm_kubernetes_cluster" "main" {
   }
 
   addon_profile {
+    ingress_application_gateway {
+      enabled    = var.ingress_application_gateway_id != null
+      gateway_id = var.ingress_application_gateway_id
+    }
+
     http_application_routing {
       enabled = var.enable_http_application_routing
     }
@@ -166,4 +173,11 @@ resource "azurerm_log_analytics_solution" "main" {
   tags = var.tags
 }
 
+resource "azurerm_role_assignment" "ingress_gw_management" {
+  principal_id         = azurerm_kubernetes_cluster.main.addon_profile[0].ingress_application_gateway[0].ingress_application_gateway_identity[0].object_id
+  scope                = var.ingress_application_gateway_id
+  role_definition_name = "Contributor"
+  description          = "Allow application gateway controller to manage the application gateway"
 
+  count = var.ingress_application_gateway_id == null ? 0 : 1
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -74,3 +74,7 @@ output "admin_username" {
 output "admin_password" {
   value = length(azurerm_kubernetes_cluster.main.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.main.kube_admin_config.0.password : ""
 }
+
+output "ingress_application_gateway_identity" {
+  value = var.ingress_application_gateway_id != null ? flatten(azurerm_kubernetes_cluster.main.addon_profile[*].ingress_application_gateway[*].ingress_application_gateway_identity[*]) : []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -92,6 +92,12 @@ variable "os_disk_size_gb" {
   default     = 50
 }
 
+variable "os_disk_type" {
+  description = "(Optional) Type of disk the nodes should use for the Operating System. Possible values are `Ephemeral` and `Managed`. Defaults to `Managed`."
+  type        = string
+  default     = "Managed"
+}
+
 variable "private_cluster_enabled" {
   description = "If true cluster API server will be exposed only on internal IP address and available only in cluster vnet."
   type        = bool
@@ -288,4 +294,10 @@ variable "enable_host_encryption" {
   description = "Enable Host Encryption for default node pool. Encryption at host feature must be enabled on the subscription: https://docs.microsoft.com/azure/virtual-machines/linux/disks-enable-host-based-encryption-cli"
   type        = bool
   default     = false
+}
+
+variable "ingress_application_gateway_id" {
+  description = "(Optional) ID of the Application Gateway should be used for ingress"
+  type        = string
+  default     = null
 }


### PR DESCRIPTION
This adds support for using an application gateway for ingressing traffic into the cluster. The Application Gateway Ingress Controller, which will be deployed into the cluster, is granted the `Contributor` role to modify the gateway as it sees fit.

Note that the controller will need to be granted the `Microsoft.Network/publicIPAddresses/read` permission on the IP address associated with the gateway for any `ingress` Kubernetes resources to have their address correctly updated.

This also adds support for setting the O/S disk type to `Ephemeral`.


Fixes #114 #115
