### PR TITLE
Add support for custom node_resource_group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,7 @@ resource "azurerm_kubernetes_cluster" "main" {
   dns_prefix              = var.prefix
   sku_tier                = var.sku_tier
   private_cluster_enabled = var.private_cluster_enabled
+  node_resource_group     = var.node_resource_group == "" ? null : var.node_resource_group
 
   linux_profile {
     admin_username = var.admin_username

--- a/variables.tf
+++ b/variables.tf
@@ -289,3 +289,9 @@ variable "enable_host_encryption" {
   type        = bool
   default     = false
 }
+
+variable "node_resource_group" {
+  description = "The name of the Resource Group where the Kubernetes Nodes should exist. Changing this forces a new resource to be created."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-aks .
$ docker run --rm azure-aks /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 
Added support for custom node_resource_group. 

Changes proposed in the pull request:


