### PR TITLE
Adding option to enable public fqdn zone for private cluster

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,13 +8,14 @@ module "ssh-key" {
 }
 
 resource "azurerm_kubernetes_cluster" "main" {
-  name                    = var.cluster_name == null ? "${var.prefix}-aks" : var.cluster_name
-  kubernetes_version      = var.kubernetes_version
-  location                = data.azurerm_resource_group.main.location
-  resource_group_name     = data.azurerm_resource_group.main.name
-  dns_prefix              = var.prefix
-  sku_tier                = var.sku_tier
-  private_cluster_enabled = var.private_cluster_enabled
+  name                                = var.cluster_name == null ? "${var.prefix}-aks" : var.cluster_name
+  kubernetes_version                  = var.kubernetes_version
+  location                            = data.azurerm_resource_group.main.location
+  resource_group_name                 = data.azurerm_resource_group.main.name
+  dns_prefix                          = var.prefix
+  sku_tier                            = var.sku_tier
+  private_cluster_enabled             = var.private_cluster_enabled
+  private_cluster_public_fqdn_enabled = var.private_cluster_public_fqdn_enabled
 
   linux_profile {
     admin_username = var.admin_username

--- a/variables.tf
+++ b/variables.tf
@@ -289,3 +289,9 @@ variable "enable_host_encryption" {
   type        = bool
   default     = false
 }
+
+variable "private_cluster_public_fqdn_enabled" {
+  description = "Enable public fqdn for private cluster"
+  type        = bool
+  default     = false
+}

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.46"
+      version = "~> 2.75"
     }
   }
 


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-aks .
$ docker run --rm azure-aks /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 

Changes proposed in the pull request:

Specifies whether a Public FQDN for this Private Cluster should be added