### PR TITLE
Added output for kube_admin_config_raw

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -39,6 +39,11 @@ output "kube_config_raw" {
   value     = azurerm_kubernetes_cluster.main.kube_config_raw
 }
 
+output "kube_admin_config_raw" {
+  sensitive = true
+  value     = azurerm_kubernetes_cluster.main.kube_admin_config_raw
+}
+
 output "http_application_routing_zone_name" {
   value = length(azurerm_kubernetes_cluster.main.addon_profile) > 0 && length(azurerm_kubernetes_cluster.main.addon_profile[0].http_application_routing) > 0 ? azurerm_kubernetes_cluster.main.addon_profile[0].http_application_routing[0].http_application_routing_zone_name : ""
 }


### PR DESCRIPTION
Changes proposed in the pull request:

Added output for ```kube_admin_config_raw``` so this can be used to automate day 2 operations after the deployment has been done.
