### PR TITLE
Add disk_encryption_set_id variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ resource "azurerm_kubernetes_cluster" "main" {
   kubernetes_version      = var.kubernetes_version
   location                = data.azurerm_resource_group.main.location
   resource_group_name     = data.azurerm_resource_group.main.name
+  node_resource_group     = var.node_resource_group
   dns_prefix              = var.prefix
   sku_tier                = var.sku_tier
   private_cluster_enabled = var.private_cluster_enabled

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@ resource "azurerm_kubernetes_cluster" "main" {
   dns_prefix              = var.prefix
   sku_tier                = var.sku_tier
   private_cluster_enabled = var.private_cluster_enabled
+  disk_encryption_set_id  = var.disk_encryption_set_id
 
   linux_profile {
     admin_username = var.admin_username

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,6 +39,11 @@ output "kube_config_raw" {
   value     = azurerm_kubernetes_cluster.main.kube_config_raw
 }
 
+output "kube_admin_config_raw" {
+  sensitive = true
+  value     = azurerm_kubernetes_cluster.main.kube_admin_config_raw
+}
+
 output "http_application_routing_zone_name" {
   value = length(azurerm_kubernetes_cluster.main.addon_profile) > 0 && length(azurerm_kubernetes_cluster.main.addon_profile[0].http_application_routing) > 0 ? azurerm_kubernetes_cluster.main.addon_profile[0].http_application_routing[0].http_application_routing_zone_name : ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -318,3 +318,9 @@ variable "enable_host_encryption" {
   type        = bool
   default     = false
 }
+
+variable "node_resource_group" {
+  description = "The auto-generated Resource Group which contains the resources for this Managed Kubernetes Cluster."
+  type        = string
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -324,3 +324,9 @@ variable "node_resource_group" {
   type        = string
   default     = null
 }
+
+variable "disk_encryption_set_id" {
+  description = "(Optional) The ID of the Disk Encryption Set which should be used for the Nodes and Volumes."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
This PR adds support for custom [disk encryption set](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#disk_encryption_set_id) that default value is null