### PR TITLE
Add `os_disk_type` for node pools

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ resource "azurerm_kubernetes_cluster" "main" {
       node_count             = var.agents_count
       vm_size                = var.agents_size
       os_disk_size_gb        = var.os_disk_size_gb
+      os_disk_type           = var.os_disk_type
       vnet_subnet_id         = var.vnet_subnet_id
       enable_auto_scaling    = var.enable_auto_scaling
       max_count              = null
@@ -54,6 +55,7 @@ resource "azurerm_kubernetes_cluster" "main" {
       name                   = var.agents_pool_name
       vm_size                = var.agents_size
       os_disk_size_gb        = var.os_disk_size_gb
+      os_disk_type           = var.os_disk_type
       vnet_subnet_id         = var.vnet_subnet_id
       enable_auto_scaling    = var.enable_auto_scaling
       max_count              = var.agents_max_count

--- a/variables.tf
+++ b/variables.tf
@@ -92,6 +92,12 @@ variable "os_disk_size_gb" {
   default     = 50
 }
 
+variable "os_disk_type" {
+  description = "The type of disk which should be used for the Operating System. Possible values are Ephemeral and Managed. Defaults to Managed. Changing this forces a new resource to be created."
+  type        = string
+  default     = "Managed"
+}
+
 variable "private_cluster_enabled" {
   description = "If true cluster API server will be exposed only on internal IP address and available only in cluster vnet."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -93,7 +93,7 @@ variable "os_disk_size_gb" {
 }
 
 variable "os_disk_type" {
-  description = "The type of disk which should be used for the Operating System. Possible values are Ephemeral and Managed. Defaults to Managed. Changing this forces a new resource to be created."
+  description = "The type of disk which should be used for the Operating System. Possible values are `Ephemeral` and `Managed`. Defaults to `Managed`. Changing this forces a new resource to be created."
   type        = string
   default     = "Managed"
 }


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-aks .
$ docker run --rm azure-aks /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #114 

Changes proposed in the pull request: Finally add `os_disk_type`


