### PR TITLE
Fixing 'terraform fmt' linting

### DIFF
--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -61,8 +61,8 @@ module "aks" {
     "Agent" : "agentTag"
   }
 
-  enable_ingress_application_gateway = true
-  ingress_application_gateway_name = "${random_id.prefix.hex}-agw"
+  enable_ingress_application_gateway      = true
+  ingress_application_gateway_name        = "${random_id.prefix.hex}-agw"
   ingress_application_gateway_subnet_cidr = "10.52.1.0/24"
 
   network_policy                 = "azure"

--- a/test/terraform_aks_test.go
+++ b/test/terraform_aks_test.go
@@ -39,12 +39,9 @@ func TestTerraformBasicExample(t *testing.T) {
 			t.Fatal("Wrong output")
 		}
 	})
-
-
 }
 
 func configureTerraformOptions(t *testing.T, fixtureFolder string) *terraform.Options {
-
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located
 		TerraformDir: fixtureFolder,


### PR DESCRIPTION
Trivial, running `terraform fmt -recursive` against the repo. I spotted this while testing the CI branch