### PR TITLE
workaround for recreate bug

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -156,7 +156,7 @@ resource "azurerm_kubernetes_cluster" "main" {
 resource "azurerm_log_analytics_workspace" "main" {
   count               = var.enable_log_analytics_workspace ? 1 : 0
   name                = var.cluster_log_analytics_workspace_name == null ? "${var.prefix}-workspace" : var.cluster_log_analytics_workspace_name
-  location            = data.azurerm_resource_group.main.location
+  location            = coalesce(var.location, data.azurerm_resource_group.main.location)
   resource_group_name = var.resource_group_name
   sku                 = var.log_analytics_workspace_sku
   retention_in_days   = var.log_retention_in_days

--- a/main.tf
+++ b/main.tf
@@ -167,7 +167,7 @@ resource "azurerm_log_analytics_workspace" "main" {
 resource "azurerm_log_analytics_solution" "main" {
   count                 = var.enable_log_analytics_workspace ? 1 : 0
   solution_name         = "ContainerInsights"
-  location              = data.azurerm_resource_group.main.location
+  location              = coalesce(var.location, data.azurerm_resource_group.main.location)
   resource_group_name   = var.resource_group_name
   workspace_resource_id = azurerm_log_analytics_workspace.main[0].id
   workspace_name        = azurerm_log_analytics_workspace.main[0].name

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ module "ssh-key" {
 resource "azurerm_kubernetes_cluster" "main" {
   name                    = var.cluster_name == null ? "${var.prefix}-aks" : var.cluster_name
   kubernetes_version      = var.kubernetes_version
-  location                = data.azurerm_resource_group.main.location
+  location                = coalesce(var.location, data.azurerm_resource_group.main.location)
   resource_group_name     = data.azurerm_resource_group.main.name
   node_resource_group     = var.node_resource_group
   dns_prefix              = var.prefix

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -61,8 +61,8 @@ module "aks" {
     "Agent" : "agentTag"
   }
 
-  enable_ingress_application_gateway = true
-  ingress_application_gateway_name = "${random_id.prefix.hex}-agw"
+  enable_ingress_application_gateway      = true
+  ingress_application_gateway_name        = "${random_id.prefix.hex}-agw"
   ingress_application_gateway_subnet_cidr = "10.52.1.0/24"
 
   network_policy                 = "azure"

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,12 @@ variable "cluster_log_analytics_workspace_name" {
   default     = null
 }
 
+variable "location" {
+  description = "Location of cluster, if not defined it will be read from the resource-group"
+  type        = string
+  default     = null
+}
+
 variable "prefix" {
   description = "(Required) The prefix for the resources created in the specified Azure Resource Group"
   type        = string


### PR DESCRIPTION
Changes proposed in the pull request:

This allows to define `location` for the resources explicitly. Because if you have slight diffs on the resource group (like for instance a label being propagated by a mitigating policy), then terraform will say that the `location` is only known after apply, and this will again trigger a recreate on the cluster - blowing the whole cluster away.

The change is backwards-compatible, as the new parameter is opt-in, and old behaviour of reading location from resource-group is preserved.