### PR TITLE
Adding the private_dns_zone_id input variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ module "aks" {
     "Agent" : "defaultnodepoolagent"
   }
 
-  enable_ingress_application_gateway = true
-  ingress_application_gateway_name = "aks-agw"
+  enable_ingress_application_gateway      = true
+  ingress_application_gateway_name        = "aks-agw"
   ingress_application_gateway_subnet_cidr = "10.52.1.0/24"
 
   network_policy                 = "azure"

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@ resource "azurerm_kubernetes_cluster" "main" {
   dns_prefix              = var.prefix
   sku_tier                = var.sku_tier
   private_cluster_enabled = var.private_cluster_enabled
+  private_dns_zone_id     = var.private_dns_zone_id
 
   linux_profile {
     admin_username = var.admin_username

--- a/variables.tf
+++ b/variables.tf
@@ -338,7 +338,7 @@ variable "node_resource_group" {
 }
 
 variable "private_dns_zone_id" {
-  description = "(Optional) Either the ID of Private DNS Zone which should be delegated to this Cluster, System to have AKS manage this or None. In case of None you will need to bring your own DNS server and set up resolving, otherwise cluster will have issues after provisioning. Changing this forces a new resource to be created."
+  description = "(Optional) Either the ID of Private DNS Zone which should be delegated to this Cluster, `System` to have AKS manage this or `None`. In case of `None` you will need to bring your own DNS server and set up resolving, otherwise cluster will have issues after provisioning. Changing this forces a new resource to be created."
   type        = string
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -336,3 +336,9 @@ variable "node_resource_group" {
   type        = string
   default     = null
 }
+
+variable "private_dns_zone_id" {
+  description = "(Optional) Either the ID of Private DNS Zone which should be delegated to this Cluster, System to have AKS manage this or None. In case of None you will need to bring your own DNS server and set up resolving, otherwise cluster will have issues after provisioning. Changing this forces a new resource to be created."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-aks .
$ docker run --rm azure-aks /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes https://github.com/Azure/terraform-azurerm-aks/issues/120

Changes proposed in the pull request:

Added an optional input variable to accept private_dns_zone_id
First time contributing to this repo. Hopefully, this helps. The tests passed and ran terrafmt.

BTW: Sorry about the closed, duplicate, unmerged pull requests. Third time is the charm! 😄 
