### PR TITLE
Update defaults for variables of type list

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -149,7 +149,7 @@ variable "rbac_aad_managed" {
 variable "rbac_aad_admin_group_object_ids" {
   description = "Object ID of groups with admin access."
   type        = list(string)
-  default     = null
+  default     = []
 }
 
 variable "rbac_aad_client_app_id" {
@@ -257,7 +257,7 @@ variable "enable_node_public_ip" {
 variable "agents_availability_zones" {
   description = "(Optional) A list of Availability Zones across which the Node Pool should be spread. Changing this forces a new resource to be created."
   type        = list(string)
-  default     = null
+  default     = []
 }
 
 variable "agents_labels" {


### PR DESCRIPTION
Terraform converts the given default value to the specified type. Set an
empty list `[]` default for variables of type list `list()`

Signed-off-by: Evans Murithi <murithievans80@gmail.com>

<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-aks .
$ docker run --rm azure-aks /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->