### PR TITLE
fix output addon_profile not supported in provider 3.10.0

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -87,6 +87,11 @@ output "admin_password" {
   value = length(azurerm_kubernetes_cluster.main.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.main.kube_admin_config.0.password : ""
 }
 
-output "addon_profile" {
-  value = try(azurerm_kubernetes_cluster.main.addon_profile.0, null)
+output "http_application_routing_enabled" {
+  value = try(azurerm_kubernetes_cluster.main.http_application_routing_enabled, null)
 }
+
+output "azure_policy_enabled" {
+  value = try(azurerm_kubernetes_cluster.main.azure_policy_enabled, null)
+}
+


### PR DESCRIPTION
The `addon_profile` has been removed in this version of the provider:

https://github.com/hashicorp/terraform-provider-azurerm/blob/main/website/docs/guides/3.0-upgrade-guide.html.markdown#data-source-azurerm_kubernetes_cluster

Tested with provider version 3.10.0

```
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 3.10.0"
    }
  }

  required_version = ">= 1.1.0"
}
```

Fixes the following failure:

```
 Error: Unsupported attribute
│
│   on .terraform/modules/aks/outputs.tf line 91, in output "addon_profile":
│   91:   value = try(azurerm_kubernetes_cluster.main.addon_profile.0, null)
│
│ This object has no argument, nested block, or exported attribute named "addon_profile".
```


