### PR TITLE
Refactor output for removed `addon_profile` block. Deprecate legacy dot index syntax in outputs.

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,3 @@
-
 output "client_key" {
   sensitive = true
   value     = azurerm_kubernetes_cluster.main.kube_config[0].client_key
@@ -52,7 +51,7 @@ output "kube_admin_config_raw" {
 }
 
 output "http_application_routing_zone_name" {
-  value = azurerm_kubernetes_cluster.main.http_application_routing_enabled ? azurerm_kubernetes_cluster.main.http_application_routing_zone_name : ""
+  value = azurerm_kubernetes_cluster.main.http_application_routing_zone_name != null ? azurerm_kubernetes_cluster.main.http_application_routing_zone_name : ""
 }
 
 output "system_assigned_identity" {
@@ -64,29 +63,41 @@ output "kubelet_identity" {
 }
 
 output "admin_client_key" {
-  value = length(azurerm_kubernetes_cluster.main.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.main.kube_admin_config.0.client_key : ""
+  value = try(azurerm_kubernetes_cluster.main.kube_admin_config[0].client_key, "")
 }
 
 output "admin_client_certificate" {
-  value = length(azurerm_kubernetes_cluster.main.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.main.kube_admin_config.0.client_certificate : ""
+  value = try(azurerm_kubernetes_cluster.main.kube_admin_config[0].client_certificate, "")
 }
 
 output "admin_cluster_ca_certificate" {
-  value = length(azurerm_kubernetes_cluster.main.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.main.kube_admin_config.0.cluster_ca_certificate : ""
+  value = try(azurerm_kubernetes_cluster.main.kube_admin_config[0].cluster_ca_certificate, "")
 }
 
 output "admin_host" {
-  value = length(azurerm_kubernetes_cluster.main.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.main.kube_admin_config.0.host : ""
+  value = try(azurerm_kubernetes_cluster.main.kube_admin_config[0].host, "")
 }
 
 output "admin_username" {
-  value = length(azurerm_kubernetes_cluster.main.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.main.kube_admin_config.0.username : ""
+  value = try(azurerm_kubernetes_cluster.main.kube_admin_config[0].username, "")
 }
 
 output "admin_password" {
-  value = length(azurerm_kubernetes_cluster.main.kube_admin_config) > 0 ? azurerm_kubernetes_cluster.main.kube_admin_config.0.password : ""
+  value = try(azurerm_kubernetes_cluster.main.kube_admin_config[0].password, "")
 }
 
 output "addon_profile" {
-  value = try(azurerm_kubernetes_cluster.main.addon_profile.0, null)
+  value = {
+    aci_connector_linux                 = try(azurerm_kubernetes_cluster.main.aci_connector_linux[0], null)
+    aci_connector_linux_enabled         = can(azurerm_kubernetes_cluster.main.aci_connector_linux[0])
+    azure_policy_enabled                = azurerm_kubernetes_cluster.main.azure_policy_enabled
+    http_application_routing_enabled    = azurerm_kubernetes_cluster.main.http_application_routing_enabled
+    ingress_application_gateway         = try(azurerm_kubernetes_cluster.main.ingress_application_gateway[0], null)
+    ingress_application_gateway_enabled = can(azurerm_kubernetes_cluster.main.ingress_application_gateway[0])
+    key_vault_secrets_provider          = try(azurerm_kubernetes_cluster.main.key_vault_secrets_provider[0], null)
+    key_vault_secrets_provider_enabled  = can(azurerm_kubernetes_cluster.main.key_vault_secrets_provider[0])
+    oms_agent                           = try(azurerm_kubernetes_cluster.main.oms_agent[0], null)
+    oms_agent_enabled                   = can(azurerm_kubernetes_cluster.main.oms_agent[0])
+    open_service_mesh_enabled           = azurerm_kubernetes_cluster.main.open_service_mesh_enabled
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -86,18 +86,49 @@ output "admin_password" {
   value = try(azurerm_kubernetes_cluster.main.kube_admin_config[0].password, "")
 }
 
-output "addon_profile" {
-  value = {
-    aci_connector_linux                 = try(azurerm_kubernetes_cluster.main.aci_connector_linux[0], null)
-    aci_connector_linux_enabled         = can(azurerm_kubernetes_cluster.main.aci_connector_linux[0])
-    azure_policy_enabled                = azurerm_kubernetes_cluster.main.azure_policy_enabled
-    http_application_routing_enabled    = azurerm_kubernetes_cluster.main.http_application_routing_enabled
-    ingress_application_gateway         = try(azurerm_kubernetes_cluster.main.ingress_application_gateway[0], null)
-    ingress_application_gateway_enabled = can(azurerm_kubernetes_cluster.main.ingress_application_gateway[0])
-    key_vault_secrets_provider          = try(azurerm_kubernetes_cluster.main.key_vault_secrets_provider[0], null)
-    key_vault_secrets_provider_enabled  = can(azurerm_kubernetes_cluster.main.key_vault_secrets_provider[0])
-    oms_agent                           = try(azurerm_kubernetes_cluster.main.oms_agent[0], null)
-    oms_agent_enabled                   = can(azurerm_kubernetes_cluster.main.oms_agent[0])
-    open_service_mesh_enabled           = azurerm_kubernetes_cluster.main.open_service_mesh_enabled
-  }
+output "aci_connector_linux" {
+  value = try(azurerm_kubernetes_cluster.main.aci_connector_linux[0], null)
 }
+
+output "aci_connector_linux_enabled" {
+  value = can(azurerm_kubernetes_cluster.main.aci_connector_linux[0])
+}
+
+output "azure_policy_enabled" {
+  value = azurerm_kubernetes_cluster.main.azure_policy_enabled
+}
+
+output "http_application_routing_enabled" {
+  value = azurerm_kubernetes_cluster.main.http_application_routing_enabled
+}
+
+output "ingress_application_gateway" {
+  value = try(azurerm_kubernetes_cluster.main.ingress_application_gateway[0], null)
+}
+
+output "ingress_application_gateway_enabled" {
+  value = can(azurerm_kubernetes_cluster.main.ingress_application_gateway[0])
+}
+
+output "key_vault_secrets_provider" {
+  value = try(azurerm_kubernetes_cluster.main.key_vault_secrets_provider[0], null)
+}
+
+output "key_vault_secrets_provider_enabled" {
+  value = can(azurerm_kubernetes_cluster.main.key_vault_secrets_provider[0])
+}
+
+output "oms_agent" {
+  value = try(azurerm_kubernetes_cluster.main.oms_agent[0], null)
+}
+
+output "oms_agent_enabled" {
+  value = can(azurerm_kubernetes_cluster.main.oms_agent[0])
+}
+
+output "open_service_mesh_enabled" {
+  value = azurerm_kubernetes_cluster.main.open_service_mesh_enabled
+}
+
+
+


### PR DESCRIPTION
This patch will fix both #180 and #182.

As `addon_profile` was added by @davidkarlsen, would you please give this pr a review to see whether the new output object can work with your code? Thanks!