### PR TITLE
Improve identity related variables and output.

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -55,7 +55,7 @@ output "http_application_routing_zone_name" {
 }
 
 output "cluster_identity" {
-  value = azurerm_kubernetes_cluster.main.identity
+  value = try(azurerm_kubernetes_cluster.main.identity[0], null)
 }
 
 output "kubelet_identity" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -54,7 +54,7 @@ output "http_application_routing_zone_name" {
   value = azurerm_kubernetes_cluster.main.http_application_routing_zone_name != null ? azurerm_kubernetes_cluster.main.http_application_routing_zone_name : ""
 }
 
-output "system_assigned_identity" {
+output "cluster_identity" {
   value = azurerm_kubernetes_cluster.main.identity
 }
 

--- a/test/fixture/outputs.tf
+++ b/test/fixture/outputs.tf
@@ -7,7 +7,7 @@ output "test_aks_without_monitor_id" {
 }
 
 output "test_aks_without_monitor_identity" {
-  value = module.aks_without_monitor.system_assigned_identity
+  value = module.aks_without_monitor.cluster_identity
 }
 
 output "test_admin_client_key" {

--- a/variables.tf
+++ b/variables.tf
@@ -30,12 +30,14 @@ variable "client_id" {
   description = "(Optional) The Client ID (appId) for the Service Principal used for the AKS deployment"
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "client_secret" {
   description = "(Optional) The Client Secret (password) for the Service Principal used for the AKS deployment"
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "admin_username" {
@@ -328,9 +330,14 @@ variable "ingress_application_gateway_subnet_id" {
 }
 
 variable "identity_type" {
-  description = "(Optional) The type of identity used for the managed cluster. Conflict with `client_id` and `client_secret`. Possible values are `SystemAssigned` and `UserAssigned`. If `UserAssigned` is set, a `user_assigned_identity_id` must be set as well."
+  description = "(Optional) The type of identity used for the managed cluster. Conflict with `client_id` and `client_secret`. Possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned`(to enable both). If `UserAssigned` or `SystemAssigned, UserAssigned` is set, an `identity_ids` must be set as well."
   type        = string
   default     = "SystemAssigned"
+
+  validation {
+    condition     = var.identity_type == "SystemAssigned" || var.identity_type == "UserAssigned" || var.identity_type == "SystemAssigned, UserAssigned"
+    error_message = "`identity_type`'s possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned`(to enable both)."
+  }
 }
 
 variable "identity_ids" {

--- a/versions.tf
+++ b/versions.tf
@@ -7,5 +7,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.2"
 }


### PR DESCRIPTION
Rename `var.system_assigned_identity` to `cluster_identity`, add validation and precondition for identity-related variables. Bump Terraform required version to 1.2.0 since we've used precondition. #196 related.
