### PR TITLE
Uses Azure policies add-on in the test fixture code

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,7 @@ resource "azurerm_kubernetes_cluster" "main" {
 
   http_application_routing_enabled = var.enable_http_application_routing
 
-  azure_policy_enabled = var.enable_azure_policy
+  azure_policy_enabled = var.azure_policy_enabled
 
   dynamic "oms_agent" {
     for_each = var.enable_log_analytics_workspace ? ["oms_agent"] : []

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -40,7 +40,7 @@ module "aks" {
   vnet_subnet_id                   = azurerm_subnet.test.id
   os_disk_size_gb                  = 60
   enable_http_application_routing  = true
-  enable_azure_policy              = true
+  azure_policy_enabled             = true
   enable_host_encryption           = true
   enable_role_based_access_control = true
   rbac_aad_managed                 = true

--- a/variables.tf
+++ b/variables.tf
@@ -118,7 +118,7 @@ variable "enable_http_application_routing" {
   default     = false
 }
 
-variable "enable_azure_policy" {
+variable "azure_policy_enabled" {
   description = "Enable Azure Policy Addon."
   type        = bool
   default     = false


### PR DESCRIPTION
Rename `var.enable_azure_policy` to `var.azure_policy_enabled` to meet the naming convention.

Set `azure_policy_enabled` to true in test fixture code.

Related to #202 and #183


