### PR TITLE
feat: add support for OIDC issuer

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -138,6 +138,8 @@ resource "azurerm_kubernetes_cluster" "main" {
     service_cidr       = var.net_profile_service_cidr
   }
 
+  oidc_issuer_enabled = var.oidc_issuer_enabled
+
   tags = var.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -338,3 +338,9 @@ variable "node_resource_group" {
   type        = string
   default     = null
 }
+
+variable "oidc_issuer_enabled" {
+  description = "Enable or Disable the OIDC issuer URL. Defaults to false."
+  type        = bool
+  default     = false
+}

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.3"
+      version = "~> 3.11"
     }
   }
 


### PR DESCRIPTION
Fixes #204

The flag oidc_issuer_enabled is now a required parameter on the `azurerm_kubernetes_cluster` resource. Adding support for it.



