### PR TITLE
chore: output oidc_issuer_url from module

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -130,5 +130,6 @@ output "open_service_mesh_enabled" {
   value = azurerm_kubernetes_cluster.main.open_service_mesh_enabled
 }
 
-
-
+output "oidc_issuer_url" {
+  value = azurerm_kubernetes_cluster.main.oidc_issuer_url
+}


### PR DESCRIPTION
Pull request https://github.com/Azure/terraform-azurerm-aks/pull/205 has added support for enabling the OIDC issuer to be created with the AKS cluster.

This small PR adds support for also exposing the created issuer URL from the module to the caller. 
Note: Should have probably been part of the original PR, sorry for the noise.