### PR TITLE
Create tls-private-key only if needed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "azurerm_kubernetes_cluster" "main" {
 
       ssh_key {
         # remove any new lines using the replace interpolation function
-        key_data = replace(coalesce(var.public_ssh_key, tls_private_key.ssh.public_key_openssh), "\n", "")
+        key_data = replace(coalesce(var.public_ssh_key, tls_private_key.ssh[0].public_key_openssh), "\n", "")
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ moved {
 }
 
 resource "tls_private_key" "ssh" {
+  count = var.admin_username == null ? 0 : 1
   algorithm = "RSA"
   rsa_bits  = 2048
 }

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ moved {
 }
 
 resource "tls_private_key" "ssh" {
-  count = var.admin_username == null ? 0 : 1
+  count     = var.admin_username == null ? 0 : 1
   algorithm = "RSA"
   rsa_bits  = 2048
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -136,11 +136,11 @@ output "oidc_issuer_url" {
 
 output "generated_cluster_public_ssh_key" {
   description = "The cluster will use this generated public key as ssh key when `var.public_ssh_key` is empty or null."
-  value       = try(azurerm_kubernetes_cluster.main.linux_profile[0], null) != null ? (var.public_ssh_key == "" || var.public_ssh_key == null ? tls_private_key.ssh.public_key_openssh : null) : null
+  value       = try(azurerm_kubernetes_cluster.main.linux_profile[0], null) != null ? (var.public_ssh_key == "" || var.public_ssh_key == null ? tls_private_key.ssh[0].public_key_openssh : null) : null
 }
 
 output "generated_cluster_private_ssh_key" {
   description = "The cluster will use this generated private key as ssh key when `var.public_ssh_key` is empty or null."
   sensitive   = true
-  value       = try(azurerm_kubernetes_cluster.main.linux_profile[0], null) != null ? (var.public_ssh_key == "" || var.public_ssh_key == null ? tls_private_key.ssh.private_key_pem : null) : null
+  value       = try(azurerm_kubernetes_cluster.main.linux_profile[0], null) != null ? (var.public_ssh_key == "" || var.public_ssh_key == null ? tls_private_key.ssh[0].private_key_pem : null) : null
 }


### PR DESCRIPTION
Create the tls-private-key only if needed to avoid confusion with users not knowing the codebase.
The users might expect to use the private key when it is created, so it should not be created at all if there is no use for it.
