### PR TITLE
Add key_vault_secrets_provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -118,6 +118,14 @@ resource "azurerm_kubernetes_cluster" "main" {
     }
   }
 
+  dynamic "key_vault_secrets_provider" {
+    for_each = var.key_vault_secrets_provider_enabled ? ["key_vault_secrets_provider"] : []
+    content {
+      secret_rotation_enabled  = var.secret_rotation_enabled
+      secret_rotation_interval = var.secret_rotation_interval
+    }
+  }
+
   role_based_access_control_enabled = var.enable_role_based_access_control
 
   dynamic "azure_active_directory_role_based_access_control" {

--- a/variables.tf
+++ b/variables.tf
@@ -362,3 +362,24 @@ variable "only_critical_addons_enabled" {
   type        = bool
   default     = null
 }
+
+variable "key_vault_secrets_provider_enabled" {
+  description = "(Optional) Whether to use the Azure Key Vault Provider for Secrets Store CSI Driver in an AKS cluster. For more details: https://docs.microsoft.com/en-us/azure/aks/csi-secrets-store-driver"
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
+variable "secret_rotation_enabled" {
+  description = "Is secret rotation enabled? This variable is only used when enable_key_vault_secrets_provider is true and defaults to false"
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
+variable "secret_rotation_interval" {
+  description = "The interval to poll for secret rotation. This attribute is only set when secret_rotation is true and defaults to 2m"
+  type        = string
+  default     = "2m"
+  nullable    = false
+}


### PR DESCRIPTION
Add support for the argument `key_vault_secrets_provider`:

* https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#key_vault_secrets_provider

* https://docs.microsoft.com/en-us/azure/aks/csi-secrets-store-driver

Note that the output for this feature was already implemented in the `output.tf` file.

Fixes #210 



