### PR TITLE
Delete duplicated variable private_dns_zone_id

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -406,12 +406,6 @@ variable "node_resource_group" {
   default     = null
 }
 
-variable "private_dns_zone_id" {
-  description = "(Optional) Either the ID of Private DNS Zone which should be delegated to this Cluster, `System` to have AKS manage this or `None`. In case of `None` you will need to bring your own DNS server and set up resolving, otherwise cluster will have issues after provisioning. Changing this forces a new resource to be created."
-  type        = string
-  default     = null
-}
-
 variable "disk_encryption_set_id" {
   description = "(Optional) The ID of the Disk Encryption Set which should be used for the Nodes and Volumes. More information [can be found in the documentation](https://docs.microsoft.com/azure/aks/azure-disk-customer-managed-keys). Changing this forces a new resource to be created."
   type        = string


### PR DESCRIPTION
This is a regression introduced when merging PR #149 

There is a duplicated variable:

```
│ Error: Duplicate variable declaration
│ 
│   on .terraform/modules/aks/variables.tf line 409:
│  409: variable "private_dns_zone_id" {
│ 
│ A variable named "private_dns_zone_id" was already declared at .terraform/modules/aks/variables.tf:391,1-31. Variable names must be unique within a
│ module.
```

