### PR TITLE
fix: mark outputs as sensitive

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -10,31 +10,37 @@ output "aci_connector_linux_enabled" {
 
 output "admin_client_certificate" {
   description = "The `client_certificate` in the `azurerm_kubernetes_cluster`'s `kube_admin_config` block.  Base64 encoded public certificate used by clients to authenticate to the Kubernetes cluster."
+  sensitive   = true
   value       = try(azurerm_kubernetes_cluster.main.kube_admin_config[0].client_certificate, "")
 }
 
 output "admin_client_key" {
   description = "The `client_key` in the `azurerm_kubernetes_cluster`'s `kube_admin_config` block. Base64 encoded private key used by clients to authenticate to the Kubernetes cluster."
+  sensitive   = true
   value       = try(azurerm_kubernetes_cluster.main.kube_admin_config[0].client_key, "")
 }
 
 output "admin_cluster_ca_certificate" {
   description = "The `cluster_ca_certificate` in the `azurerm_kubernetes_cluster`'s `kube_admin_config` block. Base64 encoded public CA certificate used as the root of trust for the Kubernetes cluster."
+  sensitive   = true
   value       = try(azurerm_kubernetes_cluster.main.kube_admin_config[0].cluster_ca_certificate, "")
 }
 
 output "admin_host" {
   description = "The `host` in the `azurerm_kubernetes_cluster`'s `kube_admin_config` block. The Kubernetes cluster server host."
+  sensitive   = true
   value       = try(azurerm_kubernetes_cluster.main.kube_admin_config[0].host, "")
 }
 
 output "admin_password" {
   description = "The `password` in the `azurerm_kubernetes_cluster`'s `kube_admin_config` block. A password or token used to authenticate to the Kubernetes cluster."
+  sensitive   = true
   value       = try(azurerm_kubernetes_cluster.main.kube_admin_config[0].password, "")
 }
 
 output "admin_username" {
   description = "The `username` in the `azurerm_kubernetes_cluster`'s `kube_admin_config` block. A username used to authenticate to the Kubernetes cluster."
+  sensitive   = true
   value       = try(azurerm_kubernetes_cluster.main.kube_admin_config[0].username, "")
 }
 


### PR DESCRIPTION
Using the latest 5.0.0 + terragrunt, I have run into the following errors:

```bash
### shortened for clarity 
azurerm_kubernetes_cluster.main: Creation complete after 11m7s [id=/subscriptions/xxxx/resourceGroups/resource-group/providers/Microsoft.ContainerService/managedClusters/yyyy]

│ Error: Output refers to sensitive values
│   on outputs.tf line 11:
│   11: output "admin_client_certificate" {
│   16: output "admin_client_key" {
│   21: output "admin_cluster_ca_certificate" {
│   26: output "admin_host" {
│   31: output "admin_password" {
│   36: output "admin_username" {
 
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
╵
```

<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-aks .
$ docker run --rm azure-aks /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 

Changes proposed in the pull request:
* adding extra `sensitive = true` line into the above mentioned outputs to avoid running into this issue

