### PR TITLE
feat(aks): add microsoft defender support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -141,6 +141,13 @@ resource "azurerm_kubernetes_cluster" "main" {
       }
     }
   }
+  dynamic "microsoft_defender" {
+    for_each = var.microsoft_defender_enabled ? ["microsoft_defender"] : []
+
+    content {
+      log_analytics_workspace_id = var.log_analytics_workspace_id == null ? azurerm_log_analytics_workspace.main[0].id : var.log_analytics_workspace.id
+    }
+  }
   network_profile {
     network_plugin     = var.network_plugin
     dns_service_ip     = var.net_profile_dns_service_ip
@@ -165,15 +172,6 @@ resource "azurerm_kubernetes_cluster" "main" {
       client_secret = var.client_secret
     }
   }
-
-  dynamic "microsoft_defender" {
-    for_each = var.microsoft_defender_enabled ? ["microsoft_defender"] : []
-
-    content {
-      log_analytics_workspace_id = var.log_analytics_workspace_id == null ? azurerm_log_analytics_workspace.main[0].id : var.log_analytics_workspace.id
-    }
-  }
-
   lifecycle {
     precondition {
       condition     = (var.client_id != "" && var.client_secret != "") || (var.identity_type != "")

--- a/main.tf
+++ b/main.tf
@@ -166,6 +166,14 @@ resource "azurerm_kubernetes_cluster" "main" {
     }
   }
 
+  dynamic "microsoft_defender" {
+    for_each = var.microsoft_defender_enabled ? ["microsoft_defender"] : []
+
+    content {
+      log_analytics_workspace_id = var.log_analytics_workspace_id == null ? azurerm_log_analytics_workspace.main[0].id : var.log_analytics_workspace.id
+    }
+  }
+
   lifecycle {
     precondition {
       condition     = (var.client_id != "" && var.client_secret != "") || (var.identity_type != "")

--- a/main.tf
+++ b/main.tf
@@ -145,7 +145,7 @@ resource "azurerm_kubernetes_cluster" "main" {
     for_each = var.microsoft_defender_enabled ? ["microsoft_defender"] : []
 
     content {
-      log_analytics_workspace_id = var.log_analytics_workspace_id == null ? azurerm_log_analytics_workspace.main[0].id : var.log_analytics_workspace.id
+      log_analytics_workspace_id = coalesce(try(var.log_analytics_workspace.id, null), azurerm_log_analytics_workspace.main[0].id)
     }
   }
   network_profile {

--- a/variables.tf
+++ b/variables.tf
@@ -259,6 +259,13 @@ variable "log_retention_in_days" {
   default     = 30
 }
 
+variable "microsoft_defender_enabled" {
+  type        = bool
+  description = "(Optional) Is Microsoft Defender on the cluster enabled?"
+  default     = false
+  nullable    = false
+}
+
 variable "net_profile_dns_service_ip" {
   type        = string
   description = "(Optional) IP address within the Kubernetes service address range that will be used by cluster service discovery (kube-dns). Changing this forces a new resource to be created."
@@ -449,11 +456,4 @@ variable "vnet_subnet_id" {
   type        = string
   description = "(Optional) The ID of a Subnet where the Kubernetes Node Pool should exist. Changing this forces a new resource to be created."
   default     = null
-}
-
-variable "microsoft_defender_enabled" {
-  type        = bool
-  description = "(Optional) Is Microsoft Defender on the cluster enabled?"
-  default     = false
-  nullable    = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -450,3 +450,10 @@ variable "vnet_subnet_id" {
   description = "(Optional) The ID of a Subnet where the Kubernetes Node Pool should exist. Changing this forces a new resource to be created."
   default     = null
 }
+
+variable "microsoft_defender_enabled" {
+  type        = bool
+  description = "(Optional) Is Microsoft Defender on the cluster enabled?"
+  default     = false
+  nullable    = false
+}


### PR DESCRIPTION

<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-aks .
$ docker run --rm azure-aks /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Changes proposed in the pull request:

Adds support for a `microsoft_defender` block introduced with https://github.com/hashicorp/terraform-provider-azurerm/pull/16218/


Signed-off-by: Toni Tauro <toni.tauro@adfinis.com>
