### PR TITLE
Add GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yml
@@ -1,0 +1,120 @@
+name: Bug Report
+description: If something isn't working as expected.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out a bug report.
+
+        If you are not running the latest version of this module, please try to reproduce your bug with the latest version before opening an issue.
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: dropdown
+    attributes:
+      label: Greenfield/Brownfield provisioning
+      description: Do you reproduce the bug with a new infrastructure provisioning (greenfield) or you need an existing infrastructure with an existing terraform state (brownfield) to reproduce the bug ?
+      multiple: false
+      options:
+        - greenfield
+        - brownfield
+    validations:
+      required: true
+  - type: input
+    id: terraform
+    attributes:
+      label: Terraform Version
+      description: Which Terraform version are you using?
+      placeholder: 1.2.8
+    validations:
+      required: true
+  - type: input
+    id: module
+    attributes:
+      label: Module Version
+      description: Which module version are you using?
+      placeholder: 5.0.0
+    validations:
+      required: true
+  - type: input
+    id: azurerm
+    attributes:
+      label: AzureRM Provider Version
+      description: Which AzureRM Provider version are you using?
+      placeholder: 3.0.0
+    validations:
+      required: true
+  - type: input
+    id: resource
+    attributes:
+      label: Affected Resource(s)/Data Source(s)
+      description: Please list the affected resources and/or data sources.
+      placeholder: azurerm_XXXXX
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Terraform Configuration Files
+      description: |
+        Please provide a minimal Terraform configuration that can reproduce the issue.
+      render: hcl
+    validations:
+      required: true
+  - type: textarea
+    id: tfvars
+    attributes:
+      label: tfvars variables values
+      description: |
+        Please provide the necessary tfvars variables values to reproduce the issue. Do not share secrets or sensitive information.
+      render: hcl
+    validations:
+      required: true
+  - type: textarea
+    id: debug
+    attributes:
+      label: Debug Output/Panic Output
+      description: |
+        For long debug logs please provide a link to a GitHub Gist containing the complete debug output. Please do NOT paste the debug output in the issue; just paste a link to the Gist.
+
+        To obtain the debug output, see the [Terraform documentation on debugging](https://www.terraform.io/docs/internals/debugging.html).
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behaviour
+      description: What should have happened?
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behaviour
+      description: What actually happened?
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: |
+        Please list the steps required to reproduce the issue, e.g.
+
+        1. `terraform apply`
+  - type: input
+    id: facts
+    attributes:
+      label: Important Factoids
+      description: |
+        Are there anything atypical about your accounts that we should know? For example: Running in a Azure China/Germany/Government?
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: |
+        Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
+
+        Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Such as vendor documentation?

--- a/.github/ISSUE_TEMPLATE/Feature_Request.yml
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.yml
@@ -1,0 +1,42 @@
+name: Feature Request
+description: I have a suggestion (and might want to implement myself)!
+title: "Support for [thing]"
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the feature you are requesting.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please leave a helpful description of the feature request here.
+    validations:
+      required: true
+  - type: input
+    id: resource
+    attributes:
+      label: New or Affected Resource(s)/Data Source(s)
+      description: Please list the new or affected resources and/or data sources.
+      placeholder: azurerm_XXXXX
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Potential Terraform Configuration
+      description: Please provide an example of what the new resource or enhancement could look like in a Terraform config.
+      render: hcl
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: |
+        Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
+
+        Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation? For example:
+
+        * https://azure.microsoft.com/en-us/roadmap/virtual-network-service-endpoint-for-azure-cosmos-db/

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
This PR introduces a template to make sure the necessary information is entered in GitHub issues.
The goal is to make every new issue immediately actionable.

This template is very similar to the issue template published for https://github.com/hashicorp/terraform-provider-azurerm

