### PR TITLE
Update hashicorp/terraform-provider-azurerm to version 3.21.0 (fixes for AKS 1.24)

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -9,7 +9,7 @@ ENHANCEMENTS:
 * Add new variable `open_service_mesh_enabled` to make argument `open_service_mesh_enabled` configurable. ([#132](https://github.com/Azure/terraform-azurerm-aks/pull/132))
 * Remove `addon_profile` in the outputs since the block has been removed from provider 3.x. Extract embedded blocks inside `addon_profile` block into standalone outputs. ([#188](https://github.com/Azure/terraform-azurerm-aks/pull/188))
 * Add `nullable = true` to some variables to simplify the conditional expressions. ([#193](https://github.com/Azure/terraform-azurerm-aks/pull/193))
-* Add new variable `oidc_issuer_enabled` to make argument `oidc_issuer_enabled` configurable. ([#205](https://github.com/Azure/terraform-azurerm-aks/pull/205) 
+* Add new variable `oidc_issuer_enabled` to make argument `oidc_issuer_enabled` configurable. ([#205](https://github.com/Azure/terraform-azurerm-aks/pull/205)
 * Add new output `oidc_issuer_url` to expose the created issuer URL from the module. [#206](https://github.com/Azure/terraform-azurerm-aks/pull/206))
 * Turn monitoring on in the test code. ([#201](https://github.com/Azure/terraform-azurerm-aks/pull/201))
 * Add new variables `private_dns_zone_id` and `private_cluster_public_fqdn_enabled` to make arguments `private_dns_zone_id` and `private_cluster_public_fqdn_enabled` configurable. ([#149](https://github.com/Azure/terraform-azurerm-aks/pull/149))
@@ -35,3 +35,4 @@ BUG FIXES:
 * Loose the restriction on `tls` provider's version to include major version greater than 3.0. [#228](https://github.com/Azure/terraform-azurerm-aks/issues/228)
 * Mark some outputs as sensitive. [#231](https://github.com/Azure/terraform-azurerm-aks/pull/231)
 * Output Kubernetes Cluster Name. [#234](https://github.com/Azure/terraform-azurerm-aks/pull/234)
+* Require minimum `hashicorp/azurerm` provider version to 3.21.0 (fixes for AKS 1.24) [#238](https://github.com/Azure/terraform-azurerm-aks/pull/238)

--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ Running the `terraform plan` first to inspect the plan is strongly advised.
 
 ### Terraform and terraform-provider-azurerm version restrictions
 
-Now Terraform core's lowest version is v1.2.0 and terraform-provider-azurerm's lowest version is v3.3.0.
+Now Terraform core's lowest version is v1.2.0 and terraform-provider-azurerm's lowest version is v3.21.0.
 
 ### variable `user_assigned_identity_id` has been renamed.
 
 variable `user_assigned_identity_id` has been renamed to `identity_ids` and it's type has been changed from `string` to `list(string)`.
 
-### `addon_profile` in outputs is no longer available. 
+### `addon_profile` in outputs is no longer available.
 
-It has been broken into the following new outputs: 
+It has been broken into the following new outputs:
 
 * `aci_connector_linux`
 * `aci_connector_linux_enabled`
@@ -346,14 +346,14 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 | Name                                                                      | Version |
 |---------------------------------------------------------------------------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2  |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm)       | ~> 3.3  |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm)       | ~> 3.21 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls)                   | >= 3.1  |
 
 ## Providers
 
 | Name                                                          | Version |
 |---------------------------------------------------------------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.18.0  |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.21 |
 | <a name="provider_tls"></a> [tls](#provider\_tls)             | 4.0.1   |
 
 ## Modules

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.3"
+      version = "~> 3.21"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
When using AKS 1.24 the `hashicorp/terraform-provider-azurerm` provider has some bugs that result in a empty `kube_config` in the terraform state:

* https://github.com/hashicorp/terraform-provider-azurerm/issues/17182
* https://github.com/hashicorp/terraform-provider-azurerm/issues/18139

The version 3.21.0 is the minimum version that contains those fixes.

Fixes #236

(waiting for version 3.21.0 to be actually released https://github.com/hashicorp/terraform-provider-azurerm/blob/main/CHANGELOG.md)

