### PR TITLE
Use `private_endpoint_network_policies_enabled` instead since `enforce_private_link_endpoint_network_policies` will be removed in 4.0 provider.

### DIFF
--- a/examples/named_cluster/main.tf
+++ b/examples/named_cluster/main.tf
@@ -24,11 +24,11 @@ resource "azurerm_virtual_network" "test" {
 }
 
 resource "azurerm_subnet" "test" {
-  address_prefixes                               = ["10.52.0.0/24"]
-  name                                           = "${random_id.prefix.hex}-sn"
-  resource_group_name                            = local.resource_group.name
-  virtual_network_name                           = azurerm_virtual_network.test.name
-  enforce_private_link_endpoint_network_policies = true
+  address_prefixes                          = ["10.52.0.0/24"]
+  name                                      = "${random_id.prefix.hex}-sn"
+  resource_group_name                       = local.resource_group.name
+  virtual_network_name                      = azurerm_virtual_network.test.name
+  private_endpoint_network_policies_enabled = true
 }
 
 resource "azurerm_user_assigned_identity" "test" {

--- a/examples/startup/main.tf
+++ b/examples/startup/main.tf
@@ -24,11 +24,11 @@ resource "azurerm_virtual_network" "test" {
 }
 
 resource "azurerm_subnet" "test" {
-  address_prefixes                               = ["10.52.0.0/24"]
-  name                                           = "${random_id.prefix.hex}-sn"
-  resource_group_name                            = local.resource_group.name
-  virtual_network_name                           = azurerm_virtual_network.test.name
-  enforce_private_link_endpoint_network_policies = true
+  address_prefixes                          = ["10.52.0.0/24"]
+  name                                      = "${random_id.prefix.hex}-sn"
+  resource_group_name                       = local.resource_group.name
+  virtual_network_name                      = azurerm_virtual_network.test.name
+  private_endpoint_network_policies_enabled = true
 }
 
 module "aks" {

--- a/examples/without_monitor/main.tf
+++ b/examples/without_monitor/main.tf
@@ -24,11 +24,11 @@ resource "azurerm_virtual_network" "test" {
 }
 
 resource "azurerm_subnet" "test" {
-  address_prefixes                               = ["10.52.0.0/24"]
-  name                                           = "${random_id.prefix.hex}-sn"
-  resource_group_name                            = local.resource_group.name
-  virtual_network_name                           = azurerm_virtual_network.test.name
-  enforce_private_link_endpoint_network_policies = true
+  address_prefixes                          = ["10.52.0.0/24"]
+  name                                      = "${random_id.prefix.hex}-sn"
+  resource_group_name                       = local.resource_group.name
+  virtual_network_name                      = azurerm_virtual_network.test.name
+  private_endpoint_network_policies_enabled = true
 }
 
 module "aks_without_monitor" {


### PR DESCRIPTION
Fix #246 by using `private_endpoint_network_policies_enabled` instead in example code.