### PR TITLE
align pr-check with local machine by using docker command instead

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -13,46 +13,31 @@ jobs:
   prepr-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: hashicorp/setup-terraform@v2
       - name: checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: '>=1.17.0'
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14
-      - name: make tools
-        run: |
-          make tools
       - name: gofmtcheck
         run: |
-          make gofmtcheck
+          docker run --rm -v $(pwd):/src -w /src mcr.microsoft.com/azterraform:latest make gofmtcheck
       - name: gencheck
         run: |
-          make gencheck
+          docker run --rm -v $(pwd):/src -w /src mcr.microsoft.com/azterraform:latest make gencheck
       - name: tfvalidatecheck
         run: |
-          make tfvalidatecheck
+          docker run --rm -v $(pwd):/src -w /src mcr.microsoft.com/azterraform:latest make tfvalidatecheck
       - name: tffmtcheck
         run: |
-          make tffmtcheck
+          docker run --rm -v $(pwd):/src -w /src mcr.microsoft.com/azterraform:latest make tffmtcheck
       - name: terrafmtcheck
         run: |
-          make terrafmtcheck
+          docker run --rm -v $(pwd):/src -w /src mcr.microsoft.com/azterraform:latest make terrafmtcheck
       - name: golint
         run: |
-          make golint
+          docker run --rm -v $(pwd):/src -w /src mcr.microsoft.com/azterraform:latest make golint
       - name: tflint
         run: |
-          make tflint
+          docker run --rm -v $(pwd):/src -w /src mcr.microsoft.com/azterraform:latest make tflint
       - name: Run Checkov action
         id: checkov
         if: ${{env.SKIP_CHECKOV == ''}}
-        uses: bridgecrewio/checkov-action@master
-        with:
-          directory: ./
-          framework: terraform
-          quiet: true
-          output_format: sarif
-          download_external_modules: true
+        run: |
+          docker run --rm -v $(pwd):/src -w /src mcr.microsoft.com/azterraform:latest make checkovcheck


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-aks .
$ docker run --rm azure-aks /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 

Changes proposed in the pull request:


