### PR TITLE
Improve placeholders for visibility in the UX

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yml
@@ -30,7 +30,7 @@ body:
     attributes:
       label: Terraform Version
       description: Which Terraform version are you using?
-      placeholder: 1.2.8
+      placeholder: Example value, 1.2.8
     validations:
       required: true
   - type: input
@@ -38,7 +38,7 @@ body:
     attributes:
       label: Module Version
       description: Which module version are you using?
-      placeholder: 5.0.0
+      placeholder: Example value, 6.0.0
     validations:
       required: true
   - type: input
@@ -46,7 +46,7 @@ body:
     attributes:
       label: AzureRM Provider Version
       description: Which AzureRM Provider version are you using?
-      placeholder: 3.0.0
+      placeholder: Example value, 3.21.1
     validations:
       required: true
   - type: input


### PR DESCRIPTION
I was opening a bug and the green "Submit new issue" button was disabled because of a missing required value. I spent a lot of time understanding what the problem was because I could not distinguish the placeholder from the actual value:

### Placeholder:
![Screenshot 2022-09-28 at 09 28 49](https://user-images.githubusercontent.com/789701/192720626-c5d14345-de45-4750-834d-686b865ef36b.png)

### Actual value typed in:

![Screenshot 2022-09-28 at 09 28 42](https://user-images.githubusercontent.com/789701/192720693-7aa7a7f7-4701-4fa6-9c44-98afd6923ab8.png)


This patch improves the placeholders so that it is more visibile if the user forgot to enter actual data.