### PR TITLE
Ignore `scripts` soft link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ README-generated.md
 .tflint_example.hcl
 
 tfmod-scaffold/
+scripts


### PR DESCRIPTION
This pr add `scritps` soft link generated by tfmod-scaffold to `.gitignore` file.