### PR TITLE
Fix #316 `current client lacks permissions to read Key Rotation Policy` issue

### DIFF
--- a/examples/named_cluster/key_vault.tf
+++ b/examples/named_cluster/key_vault.tf
@@ -44,5 +44,7 @@ resource "azurerm_key_vault_access_policy" "current_user" {
     "Get",
     "Create",
     "Delete",
+    "GetRotationPolicy",
+    "Recover",
   ]
 }

--- a/examples/startup/disk_encryption_set.tf
+++ b/examples/startup/disk_encryption_set.tf
@@ -90,5 +90,7 @@ resource "azurerm_key_vault_access_policy" "current_user" {
     "Get",
     "Create",
     "Delete",
+    "GetRotationPolicy",
+    "Recover",
   ]
 }

--- a/examples/without_monitor/disk_encryption_set.tf
+++ b/examples/without_monitor/disk_encryption_set.tf
@@ -90,5 +90,7 @@ resource "azurerm_key_vault_access_policy" "current_user" {
     "Get",
     "Create",
     "Delete",
+    "GetRotationPolicy",
+    "Recover",
   ]
 }


### PR DESCRIPTION
## Describe your changes

This pull request amended the missing Key Vault keys permissions that examples require now.

## Issue number

#316

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

