### PR TITLE
make prefix variable optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -527,6 +527,13 @@ resource "azurerm_log_analytics_workspace" "main" {
   retention_in_days   = var.log_retention_in_days
   sku                 = var.log_analytics_workspace_sku
   tags                = var.tags
+
+  lifecycle {
+    precondition {
+      condition     = var.cluster_log_analytics_workspace_name == null && var.prefix == null
+      error_message = "Either `cluster_log_analytics_workspace_name` or `prefix` must be set - Used in the name of the log analytics workspace."
+    }
+  }
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,7 @@
 variable "prefix" {
   type        = string
-  description = "(Required) The prefix for the resources created in the specified Azure Resource Group"
+  description = "(Optional) The prefix for the resources created in the specified Azure Resource Group"
+  default     = "null"
 }
 
 variable "resource_group_name" {


### PR DESCRIPTION
## Describe your changes

When providing a name for the Log Analytics Workspace (var.cluster_log_analytics_workspace_name) and a DNS prefix is not required for the cluster (dns_prefix argument within azurerm_kubernetes_cluster.main), the prefix variable is not required and should therefore be made optional.

## Issue number

#308 

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Thanks for your cooperation!

