### PR TITLE
Fix example multiple_node_pools

### DIFF
--- a/examples/multiple_node_pools/main.tf
+++ b/examples/multiple_node_pools/main.tf
@@ -34,9 +34,9 @@ resource "azurerm_subnet" "test" {
 locals {
   nodes = {
     for i in range(3) : "worker${i}" => {
-      name       = substr("worker${i}${random_id.prefix.hex}", 0, 12)
-      vm_size    = "Standard_D2s_v3"
-      node_count = 1
+      name           = substr("worker${i}${random_id.prefix.hex}", 0, 12)
+      vm_size        = "Standard_D2s_v3"
+      node_count     = 1
       vnet_subnet_id = azurerm_subnet.test.id
     }
   }

--- a/examples/multiple_node_pools/main.tf
+++ b/examples/multiple_node_pools/main.tf
@@ -37,6 +37,7 @@ locals {
       name       = substr("worker${i}${random_id.prefix.hex}", 0, 12)
       vm_size    = "Standard_D2s_v3"
       node_count = 1
+      vnet_subnet_id = azurerm_subnet.test.id
     }
   }
 }


### PR DESCRIPTION
## Describe your changes

The `multiple_node_pools` example failed the test because we didn't set `vnet_subnet_id`. This pr fixed this issue.

## Issue number

#000

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

