### PR TITLE
User `location` returned from data source for log analytics solution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ No modules.
 | [null_resource.kubernetes_version_keeper](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)                               | resource    |
 | [null_resource.pool_name_keeper](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)                                        | resource    |
 | [tls_private_key.ssh](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)                                                 | resource    |
+| [azurerm_log_analytics_workspace.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace)             | data source |
 | [azurerm_resource_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group)                               | data source |
 
 ## Inputs

--- a/examples/named_cluster/main.tf
+++ b/examples/named_cluster/main.tf
@@ -39,7 +39,7 @@ resource "azurerm_user_assigned_identity" "test" {
 
 # Just for demo purpose, not necessary to named cluster.
 resource "azurerm_log_analytics_workspace" "main" {
-  location            = local.resource_group.location
+  location            = coalesce(var.log_analytics_workspace_location, local.resource_group.location)
   name                = "prefix-workspace"
   resource_group_name = local.resource_group.name
   retention_in_days   = 30

--- a/examples/named_cluster/main.tf
+++ b/examples/named_cluster/main.tf
@@ -47,7 +47,7 @@ resource "azurerm_log_analytics_workspace" "main" {
 }
 
 resource "azurerm_log_analytics_solution" "main" {
-  location              = local.resource_group.location
+  location              = coalesce(var.log_analytics_workspace_location, local.resource_group.location)
   resource_group_name   = local.resource_group.name
   solution_name         = "ContainerInsights"
   workspace_name        = azurerm_log_analytics_workspace.main.name

--- a/examples/named_cluster/variables.tf
+++ b/examples/named_cluster/variables.tf
@@ -13,6 +13,10 @@ variable "location" {
   default = "eastus"
 }
 
+variable "log_analytics_workspace_location" {
+  default = null
+}
+
 variable "managed_identity_principal_id" {
   type    = string
   default = null

--- a/main.tf
+++ b/main.tf
@@ -668,7 +668,7 @@ data "azurerm_log_analytics_workspace" "main" {
   count = local.log_analytics_workspace != null ? 1 : 0
 
   name = local.log_analytics_workspace.name
-  // `azurerm_log_analytics_workspace`'s id format: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.OperationalInsights/workspaces/workspace1
+  # `azurerm_log_analytics_workspace`'s id format: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.OperationalInsights/workspaces/workspace1
   resource_group_name = split("/", local.log_analytics_workspace.id)[4]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -667,15 +667,16 @@ locals {
 data "azurerm_log_analytics_workspace" "main" {
   count = local.log_analytics_workspace != null ? 1 : 0
 
-  name                = local.log_analytics_workspace.name
-  resource_group_name = coalesce(var.log_analytics_workspace_resource_group_name, var.resource_group_name)
+  name = local.log_analytics_workspace.name
+  // `azurerm_log_analytics_workspace`'s id format: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.OperationalInsights/workspaces/workspace1
+  resource_group_name = split("/", local.log_analytics_workspace.id)[4]
 }
 
 resource "azurerm_log_analytics_solution" "main" {
   count = local.create_analytics_solution ? 1 : 0
 
   location              = data.azurerm_log_analytics_workspace.main[0].location
-  resource_group_name   = coalesce(var.log_analytics_workspace_resource_group_name, var.resource_group_name)
+  resource_group_name   = data.azurerm_log_analytics_workspace.main[0].resource_group_name
   solution_name         = "ContainerInsights"
   workspace_name        = local.log_analytics_workspace.name
   workspace_resource_id = local.log_analytics_workspace.id

--- a/main.tf
+++ b/main.tf
@@ -373,7 +373,9 @@ resource "azurerm_kubernetes_cluster" "main" {
     service_cidr      = var.net_profile_service_cidr
 
     dynamic "load_balancer_profile" {
-      for_each = var.load_balancer_profile_enabled && var.load_balancer_sku == "standard" ? ["load_balancer_profile"] : []
+      for_each = var.load_balancer_profile_enabled && var.load_balancer_sku == "standard" ? [
+        "load_balancer_profile"
+      ] : []
 
       content {
         idle_timeout_in_minutes     = var.load_balancer_profile_idle_timeout_in_minutes
@@ -662,10 +664,17 @@ locals {
   azurerm_log_analytics_workspace_name = try(azurerm_log_analytics_workspace.main[0].name, null)
 }
 
+data "azurerm_log_analytics_workspace" "main" {
+  count = local.log_analytics_workspace != null ? 1 : 0
+
+  name                = local.log_analytics_workspace.name
+  resource_group_name = coalesce(var.log_analytics_workspace_resource_group_name, var.resource_group_name)
+}
+
 resource "azurerm_log_analytics_solution" "main" {
   count = local.create_analytics_solution ? 1 : 0
 
-  location              = coalesce(var.location, data.azurerm_resource_group.main.location)
+  location              = data.azurerm_log_analytics_workspace.main[0].location
   resource_group_name   = coalesce(var.log_analytics_workspace_resource_group_name, var.resource_group_name)
   solution_name         = "ContainerInsights"
   workspace_name        = local.log_analytics_workspace.name

--- a/test/e2e/terraform_aks_test.go
+++ b/test/e2e/terraform_aks_test.go
@@ -103,3 +103,18 @@ func TestExamplesWithoutAssertion(t *testing.T) {
 		})
 	}
 }
+
+func TestExamples_differentLocationForLogAnalyticsSolution(t *testing.T) {
+	var vars map[string]any
+	managedIdentityId := os.Getenv("MSI_ID")
+	if managedIdentityId != "" {
+		vars = map[string]any{
+			"managed_identity_principal_id": managedIdentityId,
+		}
+	}
+	vars["log_analytics_workspace_location"] = "eastus2"
+	test_helper.RunE2ETest(t, "../../", "examples/named_cluster", terraform.Options{
+		Upgrade: true,
+		Vars:    vars,
+	}, nil)
+}


### PR DESCRIPTION
## Describe your changes

As #344 described, this module would cause an error once we'd like to deploy an aks cluster with a log analytics workspace that is located in another region.

This pr added a data source to read the workspace's location to avoid this issue. It also added a new e2e test `TestExamples_differentLocationForLogAnalyticsSolution` to verify it.

## Issue number

#344 

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

