### PR TITLE
assign network contributor role to control plane identity

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -702,7 +702,7 @@ resource "azurerm_role_assignment" "acr" {
 resource "azurerm_role_assignment" "network_contributor" {
   for_each = var.create_role_assignment_network_contributor ? local.subnet_ids : []
 
-  principal_id         = azurerm_kubernetes_cluster.main.kubelet_identity[0].object_id
+  principal_id         = azurerm_kubernetes_cluster.main.identity[0].principal_id
   scope                = each.value
   role_definition_name = "Network Contributor"
 }


### PR DESCRIPTION
Assign network contributor role to control plane identity.

Now it is currently using the kubelet identity which is wrong.

Relevant docs:
https://learn.microsoft.com/en-us/azure/aks/use-managed-identity#summary-of-managed-identities

Fixes #368 



