### PR TITLE
Filter null value out from `local.subnet_ids`

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -28,11 +28,12 @@ locals {
       name = var.log_analytics_workspace.name
     }
   ) : null # Finally, the Log Analytics Workspace should be disabled.
-  subnet_ids = toset(flatten(concat([
+  potential_subnet_ids = flatten(concat([
     for pool in var.node_pools : [
       pool.vnet_subnet_id,
       pool.pod_subnet_id
     ]
-  ], [var.vnet_subnet_id])))
+  ], [var.vnet_subnet_id]))
+  subnet_ids = toset([for id in local.potential_subnet_ids : id if id != null])
 }
 


### PR DESCRIPTION
## Describe your changes

As #364 described, sometimes `local.subnet_ids` would contain `null` value, and that could cause error as the set is used as `for_each` iterator. This pr filtered `null` value out of the set to solve the issue.

## Issue number

#364 

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

