### PR TITLE
Remove constraint on `authorized_ip_ranges` when `public_network_access_enabled` is `true`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -449,10 +449,6 @@ resource "azurerm_kubernetes_cluster" "main" {
       condition     = !(var.kms_enabled && var.identity_type != "UserAssigned")
       error_message = "KMS etcd encryption doesn't work with system-assigned managed identity."
     }
-    precondition {
-      condition     = !var.public_network_access_enabled || try(contains(var.api_server_authorized_ip_ranges, "0.0.0.0/32"), false)
-      error_message = "When `public_network_access_enabled` is set to true, `0.0.0.0/32` must be added to `authorized_ip_ranges` in the `api_server_access_profile block` (https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#public_network_access_enabled)."
-    }
   }
 }
 
@@ -698,7 +694,6 @@ resource "azurerm_role_assignment" "acr" {
 # https://learn.microsoft.com/en-us/azure/aks/configure-kubenet#prerequisites
 # https://learn.microsoft.com/en-us/azure/aks/configure-azure-cni#prerequisites
 # https://github.com/Azure/terraform-azurerm-aks/issues/178
-
 resource "azurerm_role_assignment" "network_contributor" {
   for_each = var.create_role_assignment_network_contributor ? local.subnet_ids : []
 


### PR DESCRIPTION
## Describe your changes

The change introduced by #361 was inspired by this [commit](https://github.com/hashicorp/terraform-provider-azurerm/commit/afd18e49d63d4d0b3a9e573fe93686fc083a66cd) from AzureRM provider. At that time, once you set `public_network_access_enabled` to `false`, `0.0.0.0/32` would be added into `api_server_authorized_ip_ranges` from the service side, so a [notice](https://github.com/hashicorp/terraform-provider-azurerm/blob/v3.57.0/website/docs/r/kubernetes_cluster.html.markdown?plain=1#L224) as been added into the document (which seems incorrect). But this behavior occurs no more today, so this pr just remove this `precondition` block.

## Issue number

#370 

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

