### PR TITLE
Fix incorrect e2e test code so it could pass on our local machine

### DIFF
--- a/test/e2e/terraform_aks_test.go
+++ b/test/e2e/terraform_aks_test.go
@@ -38,7 +38,7 @@ func assertOutputNotEmpty(t *testing.T, output test_helper.TerraformOutput, name
 }
 
 func TestExamplesWithoutMonitor(t *testing.T) {
-	var vars map[string]interface{}
+	vars := make(map[string]interface{}, 0)
 	managedIdentityId := os.Getenv("MSI_ID")
 	if managedIdentityId != "" {
 		vars = map[string]interface{}{
@@ -63,7 +63,7 @@ func TestExamplesWithoutMonitor(t *testing.T) {
 }
 
 func TestExamplesNamedCluster(t *testing.T) {
-	var vars map[string]interface{}
+	vars := make(map[string]interface{})
 	managedIdentityId := os.Getenv("MSI_ID")
 	if managedIdentityId != "" {
 		vars = map[string]interface{}{
@@ -105,7 +105,7 @@ func TestExamplesWithoutAssertion(t *testing.T) {
 }
 
 func TestExamples_differentLocationForLogAnalyticsSolution(t *testing.T) {
-	var vars map[string]any
+	vars := make(map[string]any, 0)
 	managedIdentityId := os.Getenv("MSI_ID")
 	if managedIdentityId != "" {
 		vars = map[string]any{


### PR DESCRIPTION
## Describe your changes

The e2e test `TestExamples_differentLocationForLogAnalyticsSolution` would failed when we run e2e test on our local machine because of the incorrect initialization. This pr fixed this incorrect e2e test.

## Issue number

#000

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

