### PR TITLE
Use `lonegunmanb/public-ip/lonegunmanb` module to retrieve public ip

### DIFF
--- a/examples/named_cluster/key_vault.tf
+++ b/examples/named_cluster/key_vault.tf
@@ -7,16 +7,14 @@ resource "random_string" "key_vault_prefix" {
   upper   = false
 }
 
-data "curl" "public_ip" {
-  count = var.key_vault_firewall_bypass_ip_cidr == null ? 1 : 0
-
-  http_method = "GET"
-  uri         = "https://api.ipify.org?format=json"
+module "public_ip" {
+  source  = "lonegunmanb/public-ip/lonegunmanb"
+  version = "0.1.0"
 }
 
 locals {
   # We cannot use coalesce here because it's not short-circuit and public_ip's index will cause error
-  public_ip = var.key_vault_firewall_bypass_ip_cidr == null ? jsondecode(data.curl.public_ip[0].response).ip : var.key_vault_firewall_bypass_ip_cidr
+  public_ip = var.key_vault_firewall_bypass_ip_cidr == null ? module.public_ip.public_ip : var.key_vault_firewall_bypass_ip_cidr
 }
 
 resource "azurerm_key_vault" "des_vault" {

--- a/examples/startup/disk_encryption_set.tf
+++ b/examples/startup/disk_encryption_set.tf
@@ -7,13 +7,6 @@ resource "random_string" "key_vault_prefix" {
   numeric = false
 }
 
-data "curl" "public_ip" {
-  count = var.key_vault_firewall_bypass_ip_cidr == null ? 1 : 0
-
-  http_method = "GET"
-  uri         = "https://api.ipify.org?format=json"
-}
-
 module "public_ip" {
   source  = "lonegunmanb/public-ip/lonegunmanb"
   version = "0.1.0"

--- a/examples/startup/disk_encryption_set.tf
+++ b/examples/startup/disk_encryption_set.tf
@@ -14,9 +14,14 @@ data "curl" "public_ip" {
   uri         = "https://api.ipify.org?format=json"
 }
 
+module "public_ip" {
+  source  = "lonegunmanb/public-ip/lonegunmanb"
+  version = "0.1.0"
+}
+
 locals {
   # We cannot use coalesce here because it's not short-circuit and public_ip's index will cause error
-  public_ip = var.key_vault_firewall_bypass_ip_cidr == null ? jsondecode(data.curl.public_ip[0].response).ip : var.key_vault_firewall_bypass_ip_cidr
+  public_ip = var.key_vault_firewall_bypass_ip_cidr == null ? module.public_ip.public_ip : var.key_vault_firewall_bypass_ip_cidr
 }
 
 resource "azurerm_key_vault" "des_vault" {

--- a/examples/without_monitor/disk_encryption_set.tf
+++ b/examples/without_monitor/disk_encryption_set.tf
@@ -7,16 +7,14 @@ resource "random_string" "key_vault_prefix" {
   upper   = false
 }
 
-data "curl" "public_ip" {
-  count = var.key_vault_firewall_bypass_ip_cidr == null ? 1 : 0
-
-  http_method = "GET"
-  uri         = "https://api.ipify.org?format=json"
+module "public_ip" {
+  source  = "lonegunmanb/public-ip/lonegunmanb"
+  version = "0.1.0"
 }
 
 locals {
   # We cannot use coalesce here because it's not short-circuit and public_ip's index will cause error
-  public_ip = var.key_vault_firewall_bypass_ip_cidr == null ? jsondecode(data.curl.public_ip[0].response).ip : var.key_vault_firewall_bypass_ip_cidr
+  public_ip = var.key_vault_firewall_bypass_ip_cidr == null ? module.public_ip.public_ip : var.key_vault_firewall_bypass_ip_cidr
 }
 
 resource "azurerm_key_vault" "des_vault" {


### PR DESCRIPTION
## Describe your changes

We used to call `https://api.ipify.org?format=json` to retrieve our current public ip, but sometimes the API is unstable, and the returned temporary errors might break our e2e tests and cause the waste of time.

This pr improves that by calling [public-ip module](https://registry.terraform.io/modules/lonegunmanb/public-ip/lonegunmanb/latest), the module would fetch the public IP address from three different public APIs to ensure reliability and fallback support.

## Issue number

#000

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

