### PR TITLE
Add `node_pools` to outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -192,6 +192,11 @@ output "node_resource_group" {
   value       = azurerm_kubernetes_cluster.main.node_resource_group
 }
 
+output "node_pool" {
+  description = "The non-default node pool(s) that are created and associated with the Cluster."
+  value       = try(azurerm_kubernetes_cluster_node_pool.node_pool, null)
+}
+
 output "oidc_issuer_url" {
   description = "The OIDC issuer URL that is associated with the cluster."
   value       = azurerm_kubernetes_cluster.main.oidc_issuer_url


### PR DESCRIPTION
## Describe your changes
This change adds the `node_pools` created with `var.node_pools` to the outputs. Useful for local testing of the module 

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

