### PR TITLE
feat(http_proxy_config): Add http_proxy_config

### DIFF
--- a/CHANGELOG-v6.md
+++ b/CHANGELOG-v6.md
@@ -4,6 +4,12 @@
 
 **Merged pull requests:**
 
+- Add support for `http_proxy_config` [\#434](https://github.com/Azure/terraform-azurerm-aks/pull/434) ([isantospardo](https://github.com/isantospardo))
+
+## [Unreleased](https://github.com/Azure/terraform-azurerm-aks/tree/HEAD)
+
+**Merged pull requests:**
+
 - Output Kubernetes Cluster Network Profile [\#333](https://github.com/Azure/terraform-azurerm-aks/pull/333) ([joshua-giumelli-deltatre](https://github.com/joshua-giumelli-deltatre))
 
 ## [6.8.0](https://github.com/Azure/terraform-azurerm-aks/tree/6.8.0) (2023-04-04)

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ No modules.
 | [azurerm_role_assignment.acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment)                                 | resource    |
 | [azurerm_role_assignment.network_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment)                 | resource    |
 | [azurerm_role_assignment.network_contributor_on_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment)       | resource    |
+| [null_resource.aks_cluster_recreate](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)                                    | resource    |
 | [null_resource.kubernetes_version_keeper](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)                               | resource    |
 | [null_resource.pool_name_keeper](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource)                                        | resource    |
 | [tls_private_key.ssh](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key)                                                 | resource    |

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ resource "azurerm_kubernetes_cluster" "main" {
   workload_identity_enabled = var.workload_identity_enabled
 
   dynamic "http_proxy_config" {
-    for_each = var.http_proxy_config == true ? [] : ["http_proxy_config"]
+    for_each = var.http_proxy_config == null ? [] : ["http_proxy_config"]
     content {
       http_proxy  = var.http_proxy_config.http_proxy
       https_proxy = var.http_proxy_config.https_proxy
@@ -462,7 +462,12 @@ resource "azurerm_kubernetes_cluster" "main" {
   }
 
   lifecycle {
-    ignore_changes = [kubernetes_version]
+    ignore_changes = [
+      kubernetes_version,
+      http_proxy_config[0].no_proxy
+    ]
+
+    replace_triggered_by = [null_resource.aks_cluster_recreate]
 
     precondition {
       condition     = (var.client_id != "" && var.client_secret != "") || (var.identity_type != "")
@@ -513,6 +518,12 @@ resource "azurerm_kubernetes_cluster" "main" {
       condition     = can(coalesce(var.cluster_name, var.prefix))
       error_message = "You must set one of `var.cluster_name` and `var.prefix` to create `azurerm_kubernetes_cluster.main`."
     }
+  }
+}
+
+resource "null_resource" "aks_cluster_recreate" {
+  triggers = {
+    http_proxy_no_proxy = try(join(",", var.http_proxy_config.no_proxy), "")
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,16 @@ resource "azurerm_kubernetes_cluster" "main" {
   } /*<box>*/ : replace(k, "avm_", var.tracing_tags_prefix) => v } : {}) /*</box>*/))
   workload_identity_enabled = var.workload_identity_enabled
 
+  dynamic "http_proxy_config" {
+    for_each = var.http_proxy_config == true ? [] : ["http_proxy_config"]
+    content {
+      http_proxy  = var.http_proxy_config.http_proxy
+      https_proxy = var.http_proxy_config.https_proxy
+      no_proxy    = coalesce(var.http_proxy_config.no_proxy, [])
+      trusted_ca  = var.http_proxy_config.trusted_ca
+    }
+  }
+
   dynamic "default_node_pool" {
     for_each = var.enable_auto_scaling == true ? [] : ["default_node_pool_manually_scaled"]
 

--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ resource "azurerm_kubernetes_cluster" "main" {
     content {
       http_proxy  = var.http_proxy_config.http_proxy
       https_proxy = var.http_proxy_config.https_proxy
-      no_proxy    = coalesce(var.http_proxy_config.no_proxy, [])
+      no_proxy    = var.http_proxy_config.no_proxy
       trusted_ca  = var.http_proxy_config.trusted_ca
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -64,7 +64,7 @@ variable "http_proxy_config" {
     no_proxy    = optional(list(string))
     trusted_ca  = optional(string)
   })
-  default     = {}
+  default     = null
   description = <<-EOT
     optional(object({
       http_proxy  = (Optional) The proxy address to be used when communicating over HTTP. Changing this forces a new resource to be created.
@@ -73,7 +73,6 @@ variable "http_proxy_config" {
       trusted_ca  = (Optional) The base64 encoded alternative CA certificate content in PEM format.
   }))
 EOT
-  nullable    = false
 }
 
 variable "agents_pool_kubelet_configs" {

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,25 @@ variable "agents_min_count" {
   description = "Minimum number of nodes in a pool"
 }
 
+variable "http_proxy_config" {
+  type = object({
+    http_proxy  = optional(string)
+    https_proxy = optional(string)
+    no_proxy    = optional(list(string))
+    trusted_ca  = optional(string)
+  })
+  default     = {}
+  description = <<-EOT
+    optional(object({
+      http_proxy  = (Optional) The proxy address to be used when communicating over HTTP. Changing this forces a new resource to be created.
+      https_proxy = (Optional) The proxy address to be used when communicating over HTTPS. Changing this forces a new resource to be created.
+      no_proxy    = (Optional) The list of domains that will not use the proxy for communication. Note: If you specify the `default_node_pool.0.vnet_subnet_id`, be sure to include the Subnet CIDR in the `no_proxy` list. Note: You may wish to use Terraform's `ignore_changes` functionality to ignore the changes to this field.
+      trusted_ca  = (Optional) The base64 encoded alternative CA certificate content in PEM format.
+  }))
+EOT
+  nullable    = false
+}
+
 variable "agents_pool_kubelet_configs" {
   type = list(object({
     cpu_manager_policy        = optional(string)


### PR DESCRIPTION
## Describe your changes

Adds a HTTP(S) proxy configuration within this module like described in the upstream Terraform Kubernetes Cluster [resource](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster).

This feature is currently not implemented yet and it would let us configure a HTTP(s) proxy for our AKS nodes with a customer CA as well.

You can have a look on a fork which enabled it, please see [here](https://github.com/claranet/terraform-azurerm-aks/blob/master/README.md?plain=1#L299).

We are working on a PR already and it will be linked to this issue asap.

Thanks for your understanding and time.
## Issue number

#434 

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Fixes: https://github.com/Azure/terraform-azurerm-aks/issues/434