### PR TITLE
feat(custom-ca-trust): Enable custom_ca_trust_enabled in node_pools

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,7 @@ resource "azurerm_kubernetes_cluster" "main" {
     content {
       name                         = var.agents_pool_name
       vm_size                      = var.agents_size
+      custom_ca_trust_enabled      = var.custom_ca_trust_enabled
       enable_auto_scaling          = var.enable_auto_scaling
       enable_host_encryption       = var.enable_host_encryption
       enable_node_public_ip        = var.enable_node_public_ip
@@ -152,6 +153,7 @@ resource "azurerm_kubernetes_cluster" "main" {
     content {
       name                         = var.agents_pool_name
       vm_size                      = var.agents_size
+      custom_ca_trust_enabled      = var.custom_ca_trust_enabled
       enable_auto_scaling          = var.enable_auto_scaling
       enable_host_encryption       = var.enable_host_encryption
       enable_node_public_ip        = var.enable_node_public_ip


### PR DESCRIPTION
## Describe your changes

We would like to be able to enable custom_ca_trust_enabled within this module described in the upstream Terraform Kubernetes Cluster [resource](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster).

This feature is currently not implemented yet and it would let us configure the custom_ca, it is known it is in a [preview state](https://learn.microsoft.com/en-us/azure/aks/custom-certificate-authority) but it is already integrated into the latest available aks cluster provider

## Issue number
 
#438 

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine