### PR TITLE
Include the `azurerm_kubernetes_cluster` identity block in the module's output

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ No modules.
 | <a name="output_host"></a> [host](#output\_host) | The `host` in the `azurerm_kubernetes_cluster`'s `kube_config` block. The Kubernetes cluster server host. |
 | <a name="output_http_application_routing_enabled"></a> [http\_application\_routing\_enabled](#output\_http\_application\_routing\_enabled) | The `azurerm_kubernetes_cluster`'s `http_application_routing_enabled` argument. (Optional) Should HTTP Application Routing be enabled? |
 | <a name="output_http_application_routing_zone_name"></a> [http\_application\_routing\_zone\_name](#output\_http\_application\_routing\_zone\_name) | The `azurerm_kubernetes_cluster`'s `http_application_routing_zone_name` argument. The Zone Name of the HTTP Application Routing. |
+| <a name="output_identity"></a> [identity](#output\_identity) | The `aurerm_kubernetes-cluster`'s `identity` block. |
 | <a name="output_ingress_application_gateway"></a> [ingress\_application\_gateway](#output\_ingress\_application\_gateway) | The `azurerm_kubernetes_cluster`'s `ingress_application_gateway` block. |
 | <a name="output_ingress_application_gateway_enabled"></a> [ingress\_application\_gateway\_enabled](#output\_ingress\_application\_gateway\_enabled) | Has the `azurerm_kubernetes_cluster` turned on `ingress_application_gateway` block? |
 | <a name="output_key_vault_secrets_provider"></a> [key\_vault\_secrets\_provider](#output\_key\_vault\_secrets\_provider) | The `azurerm_kubernetes_cluster`'s `key_vault_secrets_provider` block. |

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ No modules.
 | <a name="output_host"></a> [host](#output\_host) | The `host` in the `azurerm_kubernetes_cluster`'s `kube_config` block. The Kubernetes cluster server host. |
 | <a name="output_http_application_routing_enabled"></a> [http\_application\_routing\_enabled](#output\_http\_application\_routing\_enabled) | The `azurerm_kubernetes_cluster`'s `http_application_routing_enabled` argument. (Optional) Should HTTP Application Routing be enabled? |
 | <a name="output_http_application_routing_zone_name"></a> [http\_application\_routing\_zone\_name](#output\_http\_application\_routing\_zone\_name) | The `azurerm_kubernetes_cluster`'s `http_application_routing_zone_name` argument. The Zone Name of the HTTP Application Routing. |
-| <a name="output_identity"></a> [identity](#output\_identity) | The `aurerm_kubernetes-cluster`'s `identity` block. |
+| <a name="output_identity"></a> [identity](#output\_identity) | The `azurerm_kubernetes_cluster`'s `identity` block. |
 | <a name="output_ingress_application_gateway"></a> [ingress\_application\_gateway](#output\_ingress\_application\_gateway) | The `azurerm_kubernetes_cluster`'s `ingress_application_gateway` block. |
 | <a name="output_ingress_application_gateway_enabled"></a> [ingress\_application\_gateway\_enabled](#output\_ingress\_application\_gateway\_enabled) | Has the `azurerm_kubernetes_cluster` turned on `ingress_application_gateway` block? |
 | <a name="output_key_vault_secrets_provider"></a> [key\_vault\_secrets\_provider](#output\_key\_vault\_secrets\_provider) | The `azurerm_kubernetes_cluster`'s `key_vault_secrets_provider` block. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -140,6 +140,11 @@ output "http_application_routing_zone_name" {
   value       = azurerm_kubernetes_cluster.main.http_application_routing_zone_name != null ? azurerm_kubernetes_cluster.main.http_application_routing_zone_name : ""
 }
 
+output "identity" {
+  description = "The `azurerm_kubernetes_cluster`'s `identity` block."
+  value       = azurerm_kubernetes_cluster.main.identity
+}
+
 output "ingress_application_gateway" {
   description = "The `azurerm_kubernetes_cluster`'s `ingress_application_gateway` block."
   value       = try(azurerm_kubernetes_cluster.main.ingress_application_gateway[0], null)


### PR DESCRIPTION
Added the `azurerm_kubernetes_cluster`'s identity block to the module's output



## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Thanks for your cooperation!

