### PR TITLE
use lowercase everywhere for network plugin mode overlay

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -526,16 +526,16 @@ resource "azurerm_kubernetes_cluster" "main" {
       error_message = "`oidc_issuer_enabled` must be set to `true` to enable Azure AD Workload Identity"
     }
     precondition {
-      condition     = var.network_plugin_mode != "Overlay" || var.network_plugin == "azure"
-      error_message = "When network_plugin_mode is set to Overlay, the network_plugin field can only be set to azure."
+      condition     = var.network_plugin_mode != "overlay" || var.network_plugin == "azure"
+      error_message = "When network_plugin_mode is set to `overlay`, the network_plugin field can only be set to azure."
     }
     precondition {
       condition     = var.ebpf_data_plane != "cilium" || var.network_plugin == "azure"
       error_message = "When ebpf_data_plane is set to cilium, the network_plugin field can only be set to azure."
     }
     precondition {
-      condition     = var.ebpf_data_plane != "cilium" || var.network_plugin_mode == "Overlay" || var.pod_subnet_id != null
-      error_message = "When ebpf_data_plane is set to cilium, one of either network_plugin_mode = `Overlay` or pod_subnet_id must be specified."
+      condition     = var.ebpf_data_plane != "cilium" || var.network_plugin_mode == "overlay" || var.pod_subnet_id != null
+      error_message = "When ebpf_data_plane is set to cilium, one of either network_plugin_mode = `overlay` or pod_subnet_id must be specified."
     }
     precondition {
       condition     = can(coalesce(var.cluster_name, var.prefix))
@@ -718,11 +718,11 @@ resource "azurerm_kubernetes_cluster_node_pool" "node_pool" {
       error_message = "A Node Pools name must consist of alphanumeric characters and have a maximum lenght of 8 characters (4 random chars added)"
     }
     precondition {
-      condition     = var.network_plugin_mode != "Overlay" || each.value.os_type != "Windows"
+      condition     = var.network_plugin_mode != "overlay" || each.value.os_type != "Windows"
       error_message = "Windows Server 2019 node pools are not supported for Overlay and Windows support is still in preview"
     }
     precondition {
-      condition     = var.network_plugin_mode != "Overlay" || !can(regex("^Standard_DC[0-9]+s?_v2$", each.value.vm_size))
+      condition     = var.network_plugin_mode != "overlay" || !can(regex("^Standard_DC[0-9]+s?_v2$", each.value.vm_size))
       error_message = "With with Azure CNI Overlay you can't use DCsv2-series virtual machines in node pools. "
     }
   }


### PR DESCRIPTION
## Describe your changes

Using `Overlay` instead of `overlay` triggers unnecessary cluster updates.
Fixing to user lowercase only everywhere.

## Issue number
https://github.com/Azure/terraform-azurerm-aks/issues/429 
https://github.com/hashicorp/terraform-provider-azurerm/issues/22621



