### PR TITLE
Add web_app_routing_identity block to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,5 +445,5 @@ No modules.
 | <a name="output_open_service_mesh_enabled"></a> [open\_service\_mesh\_enabled](#output\_open\_service\_mesh\_enabled) | (Optional) Is Open Service Mesh enabled? For more details, please visit [Open Service Mesh for AKS](https://docs.microsoft.com/azure/aks/open-service-mesh-about). |
 | <a name="output_password"></a> [password](#output\_password) | The `password` in the `azurerm_kubernetes_cluster`'s `kube_config` block. A password or token used to authenticate to the Kubernetes cluster. |
 | <a name="output_username"></a> [username](#output\_username) | The `username` in the `azurerm_kubernetes_cluster`'s `kube_config` block. A username used to authenticate to the Kubernetes cluster. |
-| <a name="output_web_app_routing_identity"></a> [web\_app\_routing\_identity](#output\_web\_app\_routing\_identity) | The `azurerm_kubernetes_cluster`'s `web_app_routing_identity` block. |
+| <a name="output_web_app_routing_identity"></a> [web\_app\_routing\_identity](#output\_web\_app\_routing\_identity) | The `azurerm_kubernetes_cluster`'s `web_app_routing_identity` block, it's type is a list of object. |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -445,4 +445,5 @@ No modules.
 | <a name="output_open_service_mesh_enabled"></a> [open\_service\_mesh\_enabled](#output\_open\_service\_mesh\_enabled) | (Optional) Is Open Service Mesh enabled? For more details, please visit [Open Service Mesh for AKS](https://docs.microsoft.com/azure/aks/open-service-mesh-about). |
 | <a name="output_password"></a> [password](#output\_password) | The `password` in the `azurerm_kubernetes_cluster`'s `kube_config` block. A password or token used to authenticate to the Kubernetes cluster. |
 | <a name="output_username"></a> [username](#output\_username) | The `username` in the `azurerm_kubernetes_cluster`'s `kube_config` block. A username used to authenticate to the Kubernetes cluster. |
+| <a name="output_web_app_routing_identity"></a> [web\_app\_routing\_identity](#output\_web\_app\_routing\_identity) | The `azurerm_kubernetes_cluster`'s `web_app_routing_identity` block. |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -223,3 +223,8 @@ output "username" {
   sensitive   = true
   value       = azurerm_kubernetes_cluster.main.kube_config[0].username
 }
+
+output "web_app_routing_identity" {
+  description = "The `azurerm_kubernetes_cluster`'s `web_app_routing_identity` block."
+  value       = try(azurerm_kubernetes_cluster.main.web_app_routing[0].web_app_routing_identity, null)
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -225,6 +225,6 @@ output "username" {
 }
 
 output "web_app_routing_identity" {
-  description = "The `azurerm_kubernetes_cluster`'s `web_app_routing_identity` block."
-  value       = try(azurerm_kubernetes_cluster.main.web_app_routing[0].web_app_routing_identity, null)
+  description = "The `azurerm_kubernetes_cluster`'s `web_app_routing_identity` block, it's type is a list of object."
+  value       = try(azurerm_kubernetes_cluster.main.web_app_routing[0].web_app_routing_identity, [])
 }


### PR DESCRIPTION
## Describe your changes
This add `web_app_routing_identity` to outputs, which is needed for role assignments when DNS zone and AKS Cluster are in different resource groups.

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine
