### PR TITLE
Add retry when the ingress is not ready

### DIFF
--- a/test/e2e/terraform_aks_test.go
+++ b/test/e2e/terraform_aks_test.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
 
@@ -156,6 +157,11 @@ func TestExamples_applicationGatewayIngress(t *testing.T) {
 					"bring_your_own_vnet":                             u.bringYourOwnVnet,
 					"use_brown_field_application_gateway":             u.useBrownFieldAppGw,
 					"create_role_assignments_for_application_gateway": u.createRoleBindingForAppGw,
+				},
+				MaxRetries:         20,
+				TimeBetweenRetries: time.Minute,
+				RetryableTerraformErrors: map[string]string{
+					".*is empty list of object.*": "the ingress hasn't been created, need more time",
 				},
 			}, func(t *testing.T, output test_helper.TerraformOutput) {
 				url, ok := output["ingress_endpoint"].(string)

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	test_helper "github.com/Azure/terraform-module-test-helper"
 	"github.com/gruntwork-io/terratest/modules/terraform"
@@ -137,6 +138,11 @@ func TestExampleUpgrade_applicationGw(t *testing.T) {
 					"bring_your_own_vnet":                             u.bringYourOwnVnet,
 					"use_brown_field_application_gateway":             u.useBrownFieldAppGw,
 					"create_role_assignments_for_application_gateway": u.createRoleBindingForAppGw,
+				},
+				MaxRetries:         20,
+				TimeBetweenRetries: time.Minute,
+				RetryableTerraformErrors: map[string]string{
+					".*is empty list of object.*": "the ingress hasn't been created, need more time",
 				},
 			}, currentMajorVersion)
 		})


### PR DESCRIPTION
## Describe your changes

This module might tried to create azure application gateway as cluster's ingress,  sometimes when the e2e test tried to read ingress's url, the agw was not ready yet. This pr added a retry in the test code. 
## Issue number

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

