### PR TITLE
Remove precondition on extra node pool which prevent using windows pool with overlay

### DIFF
--- a/extra_node_pool.tf
+++ b/extra_node_pool.tf
@@ -151,10 +151,6 @@ resource "azurerm_kubernetes_cluster_node_pool" "node_pool_create_before_destroy
       error_message = "A Node Pools name must consist of alphanumeric characters and have a maximum lenght of 8 characters (4 random chars added)"
     }
     precondition {
-      condition     = var.network_plugin_mode != "overlay" || each.value.os_type != "Windows"
-      error_message = "Windows Server 2019 node pools are not supported for Overlay and Windows support is still in preview"
-    }
-    precondition {
       condition     = var.network_plugin_mode != "overlay" || !can(regex("^Standard_DC[0-9]+s?_v2$", each.value.vm_size))
       error_message = "With with Azure CNI Overlay you can't use DCsv2-series virtual machines in node pools. "
     }
@@ -303,10 +299,6 @@ resource "azurerm_kubernetes_cluster_node_pool" "node_pool_create_after_destroy"
     precondition {
       condition     = can(regex("[a-z0-9]{1,8}", each.value.name))
       error_message = "A Node Pools name must consist of alphanumeric characters and have a maximum lenght of 8 characters (4 random chars added)"
-    }
-    precondition {
-      condition     = var.network_plugin_mode != "overlay" || each.value.os_type != "Windows"
-      error_message = "Windows Server 2019 node pools are not supported for Overlay and Windows support is still in preview"
     }
     precondition {
       condition     = var.network_plugin_mode != "overlay" || !can(regex("^Standard_DC[0-9]+s?_v2$", each.value.vm_size))


### PR DESCRIPTION
Remove precondition on extra node pool which prevent using windows pool with overlay since the feature is now GA

## Describe your changes

## Issue number

#511 

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

