### PR TITLE
Remove public_network_access_enabled from lifecycle block => Fixes deprecation warning during plan.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -545,7 +545,6 @@ resource "azurerm_kubernetes_cluster" "main" {
       http_application_routing_enabled,
       http_proxy_config[0].no_proxy,
       kubernetes_version,
-      public_network_access_enabled,
       # we might have a random suffix in cluster's name so we have to ignore it here, but we've traced user supplied cluster name by `null_resource.kubernetes_cluster_name_keeper` so when the name is changed we'll recreate this resource.
       name,
     ]


### PR DESCRIPTION
## Describe your changes
The fix to remove public_network_access_enabled in 8.0.0 was incomplete. Leaving the property in the lifecycle {} block still causes the warning.
## Issue number
#526 

## Checklist before requesting a review
- [X ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [X ] I have executed pre-commit on my machine
- [X ] I have passed pr-check on my machine

Thanks for your cooperation!

