### PR TITLE
Bump ContainerService API from 2023-01-02-preview to 2024-02-01

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -635,7 +635,7 @@ resource "null_resource" "kubernetes_version_keeper" {
 }
 
 resource "azapi_update_resource" "aks_cluster_post_create" {
-  type = "Microsoft.ContainerService/managedClusters@2023-01-02-preview"
+  type = "Microsoft.ContainerService/managedClusters@2024-02-01"
   body = jsonencode({
     properties = {
       kubernetesVersion = var.kubernetes_version
@@ -660,7 +660,7 @@ resource "null_resource" "http_proxy_config_no_proxy_keeper" {
 resource "azapi_update_resource" "aks_cluster_http_proxy_config_no_proxy" {
   count = can(var.http_proxy_config.no_proxy[0]) ? 1 : 0
 
-  type = "Microsoft.ContainerService/managedClusters@2023-01-02-preview"
+  type = "Microsoft.ContainerService/managedClusters@2024-02-01"
   body = jsonencode({
     properties = {
       httpProxyConfig = {


### PR DESCRIPTION
## Describe your changes

Earlier this year Azure sent out notification that the Container Service API 2023-01-02-preview support (and functionality) is ending June 20th 2024.

This PR bumps the API to the latest non-preview version: 2024-02-01

## Issue number

N/A

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Thanks for your cooperation!

