### PR TITLE
Make the Azure Key Vault public because private Key Vault requires preview API

### DIFF
--- a/examples/named_cluster/key_vault.tf
+++ b/examples/named_cluster/key_vault.tf
@@ -29,7 +29,7 @@ resource "azurerm_key_vault" "des_vault" {
 
   network_acls {
     bypass         = "AzureServices"
-    default_action = "Deny"
+    default_action = "Allow"
     ip_rules       = [local.public_ip]
   }
 }

--- a/examples/named_cluster/main.tf
+++ b/examples/named_cluster/main.tf
@@ -97,7 +97,7 @@ module "aks_cluster_name" {
   # KMS etcd encryption
   kms_enabled                  = true
   kms_key_vault_key_id         = azurerm_key_vault_key.kms.id
-  kms_key_vault_network_access = "Private"
+  kms_key_vault_network_access = "Public"
 
   depends_on = [
     azurerm_key_vault_access_policy.kms,

--- a/test/go.mod
+++ b/test/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.5
 
 require (
-	github.com/Azure/terraform-module-test-helper v0.26.0
+	github.com/Azure/terraform-module-test-helper v0.27.0
 	github.com/gruntwork-io/terratest v0.47.1
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/stretchr/testify v1.9.0


### PR DESCRIPTION
Running Microsoft Terraform module AKS end to end tests I get this new error message I have never seen before from the ARM API:

https://github.com/Azure/terraform-azurerm-aks/actions/runs/11665268834/job/32477571013?pr=598#step:3:6605

HTTP 400 "Vnet integration should be enabled when KeyVault network access is Private."

I believe this is the root cause:
https://learn.microsoft.com/en-us/azure/aks/use-kms-etcd-encryption#prerequisites ( See yellow warning box)

However Vnet Integration is still preview as far as I know. Terraform provider azurerm V4 will not support preview features. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide#aks-migration-to-stable-api

This is a workaround to get the CI running again.
This PR needs to be reverted once AKS API Vnet Integration goes GA
