### PR TITLE
fix wrongly reported sensitivity error with `client_secret`

### DIFF
--- a/role_assignments.tf
+++ b/role_assignments.tf
@@ -22,7 +22,7 @@ data "azurerm_user_assigned_identity" "cluster_identity" {
 # https://learn.microsoft.com/en-us/azure/aks/configure-azure-cni#prerequisites
 # https://github.com/Azure/terraform-azurerm-aks/issues/178
 resource "azurerm_role_assignment" "network_contributor" {
-  for_each = var.create_role_assignment_network_contributor && (var.client_id == "" || var.client_secret == "") ? local.subnet_ids : []
+  for_each = nonsensitive(var.create_role_assignment_network_contributor && (var.client_id == "" || var.client_secret == "") ? local.subnet_ids : [])
 
   principal_id         = coalesce(try(data.azurerm_user_assigned_identity.cluster_identity[0].principal_id, azurerm_kubernetes_cluster.main.identity[0].principal_id), var.client_id)
   scope                = each.value


### PR DESCRIPTION
## Describe your changes

I added the `nonsensitive` function around an argument, so using a sensitive `client_secret` no longer results in an error. This value actually isn't sensitive, because `client_secret` is only used as a condition.

## Issue number

#628

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Thanks for your cooperation!

