### PR TITLE
Enable azure monitor workspace id and grafana workspace id integration

### DIFF
--- a/azure_monitor.tf
+++ b/azure_monitor.tf
@@ -1,0 +1,16 @@
+resource "azapi_resource_action" "enable_azure_monitor_metrics" {
+  count       = var.azure_monitor_workspace_enabled && var.azure_monitor_workspace_resource_id != null ? 1 : 0
+  type        = "Microsoft.ContainerService/managedClusters@2023-01-01"
+  resource_id = azurerm_kubernetes_cluster.main.id
+  action      = "enableMonitoringMetrics"
+  method      = "POST"
+  
+  body = jsonencode({
+    properties = {
+      azureMonitorWorkspaceResourceId = var.azure_monitor_workspace_resource_id
+      grafanaResourceId               = var.grafana_enabled && var.grafana_resource_id != null ? var.grafana_resource_id : null
+    }
+  })
+
+  depends_on = [azurerm_kubernetes_cluster.main]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -223,3 +223,23 @@ output "web_app_routing_identity" {
   description = "The `azurerm_kubernetes_cluster`'s `web_app_routing_identity` block, it's type is a list of object."
   value       = try(azurerm_kubernetes_cluster.main.web_app_routing[0].web_app_routing_identity, [])
 }
+
+output "azure_monitor_workspace_enabled" {
+  description = "Is Azure Monitor workspace enabled for the AKS cluster?"
+  value       = var.azure_monitor_workspace_enabled
+}
+
+output "azure_monitor_workspace_resource_id" {
+  description = "The resource ID of the Azure Monitor workspace"
+  value       = var.azure_monitor_workspace_resource_id
+}
+
+output "grafana_enabled" {
+  description = "Is Grafana integration enabled for the AKS cluster?"
+  value       = var.grafana_enabled
+}
+
+output "grafana_resource_id" {
+  description = "The resource ID of the Grafana workspace"
+  value       = var.grafana_resource_id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1472,3 +1472,27 @@ variable "workload_identity_enabled" {
   default     = false
   description = "Enable or Disable Workload Identity. Defaults to false."
 }
+
+variable "azure_monitor_workspace_enabled" {
+  description = "Enable Azure Monitor workspace for the AKS cluster"
+  type        = bool
+  default     = false
+}
+
+variable "azure_monitor_workspace_resource_id" {
+  description = "The resource ID of the Azure Monitor workspace"
+  type        = string
+  default     = null
+}
+
+variable "grafana_enabled" {
+  description = "Enable Grafana integration for the AKS cluster"
+  type        = bool
+  default     = false
+}
+
+variable "grafana_resource_id" {
+  description = "The resource ID of the Grafana workspace"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Describe your changes
In aks cluster monitor settings we have azure monitor workspace integration and grafana workspace integration. I have added support to enable those and integrate existing workspaces into the cluster


## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

