### PR TITLE
Add upgrade_override block to azurerm_kubernetes_cluster main

### DIFF
--- a/v4/main_override.tf
+++ b/v4/main_override.tf
@@ -273,6 +273,16 @@ resource "azurerm_kubernetes_cluster" "main" {
       snapshot_controller_enabled = var.storage_profile_snapshot_controller_enabled
     }
   }
+
+  dynamic "upgrade_override" {
+    for_each = var.upgrade_override != null ? ["use_upgrade_override"] : []
+    content {
+      effective_until       = var.upgrade_override.effective_until
+      force_upgrade_enabled = var.upgrade_override.force_upgrade_enabled
+    }
+
+  }
+
   dynamic "web_app_routing" {
     for_each = var.web_app_routing == null ? [] : ["web_app_routing"]
 

--- a/v4/variables_override.tf
+++ b/v4/variables_override.tf
@@ -221,3 +221,15 @@ variable "service_mesh_profile" {
     `external_ingress_gateway_enabled` - (Optional) Is Istio External Ingress Gateway enabled? Defaults to `true`.
   EOT
 }
+
+variable "upgrade_override" {
+  type = object({
+    force_upgrade_enabled = bool
+    effective_until       = optional(string)
+  })
+  default     = null
+  description = <<-EOT
+    `force_upgrade_enabled` - (Required) Whether to force upgrade the cluster. Possible values are `true` or `false`.
+    `effective_until` - (Optional) Specifies the duration, in RFC 3339 format (e.g., `2025-10-01T13:00:00Z`), the upgrade_override values are effective. This field must be set for the `upgrade_override` values to take effect. The date-time must be within the next 30 days.
+  EOT
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1529,6 +1529,18 @@ variable "ultra_ssd_enabled" {
   description = "(Optional) Used to specify whether the UltraSSD is enabled in the Default Node Pool. Defaults to false."
 }
 
+variable "upgrade_override" {
+  type = object({
+    force_upgrade_enabled = bool
+    effective_until       = optional(string)
+  })
+  default     = null
+  description = <<-EOT
+    `force_upgrade_enabled` - (Required) Whether to force upgrade the cluster. Possible values are `true` or `false`.
+    `effective_until` - (Optional) Specifies the duration, in RFC 3339 format (e.g., `2025-10-01T13:00:00Z`), the upgrade_override values are effective. This field must be set for the `upgrade_override` values to take effect. The date-time must be within the next 30 days.
+  EOT
+}
+
 variable "vnet_subnet_id" {
   type        = string
   default     = null


### PR DESCRIPTION
## Describe your changes
Makes the `upgrade_override` block configurable on the kubernetes cluster.
This is important because if force upgrade is ever used via the cli the cluster cannot be modified via terraform unless that block is present.

Context:
I used the force-upgrade via the CLI to upgrade one of my clusters back in November. The `upgrade_override` block was detected and state updated. Now months later im starting the next upgrade cycle and this cluster cannot be updated as the `upgrade_override` block cannot be removed if present

## Issue number
![Screenshot 2025-04-16 at 2 10 00 PM](https://github.com/user-attachments/assets/e183c5df-ecd9-4532-9e6c-a96c6559fe4b)


```

│ Error: `upgrade_override` cannot be unset
│
│   with module.aks.azurerm_kubernetes_cluster.main,
│   on ../azure-aks-azurerm/v4/main.tf line 13, in resource "azurerm_kubernetes_cluster" "main":
│   13: resource "azurerm_kubernetes_cluster" "main" {
│
╵
```

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

