### PR TITLE
Remove variable validation that only works in terraform 1.9 and newer

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -394,10 +394,6 @@ variable "client_id" {
   description = "(Optional) The Client ID (appId) for the Service Principal used for the AKS deployment"
   nullable    = false
 
-  validation {
-    condition     = var.identity_ids == null || var.client_id == ""
-    error_message = "Cannot set both `client_id` and `identity_ids`."
-  }
 }
 
 variable "client_secret" {


### PR DESCRIPTION
## Describe your changes
Module cannot be used with terraform older than `1.9` despite only requiring >= `1.3` because it is doing [variable cross validation](https://www.hashicorp.com/en/blog/terraform-1-9-enhances-input-variable-validations). 
Since `1.9` is after the license change in `1.6`, I removed the validation rather than bumping the required terraform version to `1.9`

Extra context: I tried using `10.0.0-beta` now that it supports the `upgrade_override` block and the module is throwing error on init for invalid variable validation
```
Downloading registry.terraform.io/Azure/aks/azurerm 10.0.0-beta for aks...
- aks in .terraform/modules/aks/v4
╷
│ Error: Invalid reference in variable validation
│
│   on .terraform/modules/aks/v4/variables.tf line 398, in variable "client_id":
│  398:     condition     = var.identity_ids == null || var.client_id == ""
│
│ The condition for variable "client_id" can only refer to the variable
│ itself, using var.client_id.
```
## Issue number

#000



## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

