### PR TITLE
fix mark cluster_identity as sensitive

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -100,6 +100,7 @@ output "cluster_fqdn" {
 
 output "cluster_identity" {
   description = "The `azurerm_kubernetes_cluster`'s `identity` block."
+  sensitive   = true
   value       = try(azurerm_kubernetes_cluster.main.identity[0], null)
 }
 


### PR DESCRIPTION
## Describe your changes

The output variable cluster_identity is not marked as sensitive. With 

- terraform-azurerm-aks 10.1.0
- Terraform 1.11.2 
- azurerm v3.117.1 
- azapi v2.4.0. 

One could get the following error:

* Failed to execute "terraform apply -auto-approve -input=false" in ./aks/.terragrunt-cache/8CPM0_V8n0J5z1sZ5d4gER5qNWg/dVSEbMDWhC7lgE2k6UPOeVkfB7c
  ╷
  │ Error: Output refers to sensitive values
  │ 
  │   on outputs.tf line 101:
  │  101: output "cluster_identity" {
  │ 
  │ To reduce the risk of accidentally exporting sensitive data that was
  │ intended to be only internal, Terraform requires that any root module
  │ output containing sensitive data be explicitly marked as sensitive, to
  │ confirm your intent.
  │ 
  │ If you do intend to export this data, annotate the output value as
  │ sensitive by adding the following argument:
  │     sensitive = true

This PR fixes it by defining cluster_identity as sensitive.

## Issue number

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Thanks for your cooperation!

