### PR TITLE
Add missing temporary_name_for_rotation to v4 nodepool create_after_destroy override

### DIFF
--- a/v4/extra_node_pool_override.tf
+++ b/v4/extra_node_pool_override.tf
@@ -8,7 +8,8 @@ resource "azurerm_kubernetes_cluster_node_pool" "node_pool_create_before_destroy
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "node_pool_create_after_destroy" {
-  auto_scaling_enabled    = each.value.enable_auto_scaling
-  host_encryption_enabled = each.value.enable_host_encryption
-  node_public_ip_enabled  = each.value.enable_node_public_ip
+  auto_scaling_enabled        = each.value.enable_auto_scaling
+  host_encryption_enabled     = each.value.enable_host_encryption
+  node_public_ip_enabled      = each.value.enable_node_public_ip
+  temporary_name_for_rotation = each.value.temporary_name_for_rotation
 }


### PR DESCRIPTION
The azurerm provider still expects temporary_name_for_rotation to be set when any of the notable properties change on the node pool whether created before or after destroy (https://registry.terraform.io/providers/hashicorp/azurerm/4.33.0/docs/resources/kubernetes_cluster_node_pool)

It gives an error:
` Error: `temporary_name_for_rotation` must be specified when updating any of the following properties ["fips_enabled" "host_encryption_enabled" "kubelet_config" "kubelet_disk_type" "linux_os_config" "max_pods" "node_public_ip_enabled" "os_disk_size_gb" "os_disk_type" "pod_subnet_id" "snapshot_id" "ultra_ssd_enabled" "vm_size" "vnet_subnet_id" "zones"]`

## Describe your changes

Just adding the missing property to the create_after_destroy node pool in the v4 overrides

## Issue number

Mentioned in https://github.com/Azure/terraform-azurerm-aks/issues/663 and again in https://github.com/Azure/terraform-azurerm-aks/issues/677

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

