### PR TITLE
🤖 fix: remove incorrect sensitive flag from `cluster_identity` output

### DIFF
--- a/NoticeOnUpgradeTov11.0.md
+++ b/NoticeOnUpgradeTov11.0.md
@@ -15,3 +15,9 @@ This change also affects the `node_pools` variable where `node_pools[*].enable_h
 ## `var.enable_node_public_ip` has been renamed to `var.node_public_ip_enabled`
 
 This change also affects the `node_pools` variable where `node_pools[*].enable_node_public_ip` should be replaced with `node_pools[*].node_public_ip_enabled`.
+
+## `cluster_identity` output is no longer marked as sensitive
+
+The `cluster_identity` output was incorrectly marked as `sensitive = true` due to the `identity` block referencing `var.client_secret` in its `for_each` expression. This has been fixed by using the `nonsensitive()` function, and the output is no longer marked as sensitive.
+
+**Impact**: Users who previously had to mark their outputs as sensitive when using `module.aks.cluster_identity` can now remove the `sensitive = true` flag from their outputs. The cluster identity information (principal_id, tenant_id, type) is not actually sensitive data.

--- a/main.tf
+++ b/main.tf
@@ -327,7 +327,7 @@ resource "azurerm_kubernetes_cluster" "main" {
     }
   }
   dynamic "identity" {
-    for_each = var.client_id == "" || var.client_secret == "" ? ["identity"] : []
+    for_each = var.client_id == "" || nonsensitive(var.client_secret) == "" ? ["identity"] : []
 
     content {
       type         = var.identity_type

--- a/outputs.tf
+++ b/outputs.tf
@@ -100,7 +100,6 @@ output "cluster_fqdn" {
 
 output "cluster_identity" {
   description = "The `azurerm_kubernetes_cluster`'s `identity` block."
-  sensitive   = true
   value       = try(azurerm_kubernetes_cluster.main.identity[0], null)
 }
 


### PR DESCRIPTION
## Description

This PR fixes issue #683 where the `cluster_identity` output was incorrectly marked as sensitive, forcing users to mark their own outputs as sensitive unnecessarily.

## Changes Made

- **main.tf**: Updated the `identity` dynamic block to use `nonsensitive(var.client_secret)` in the `for_each` expression to prevent sensitivity propagation
- **outputs.tf**: Removed `sensitive = true` flag from the `cluster_identity` output 
- **NoticeOnUpgradeTov11.0.md**: Added documentation for this breaking change

## Root Cause

The issue occurred because the `identity` block's `for_each` expression referenced `var.client_secret`, which is marked as sensitive. This caused Terraform to treat the entire identity block as sensitive, even though the identity information (principal_id, tenant_id, type) is not actually sensitive data.

## Impact

- **Breaking Change**: Users who previously had to mark their outputs as sensitive when using `module.aks.cluster_identity` can now remove the `sensitive = true` flag
- **Improved UX**: Users no longer need to unnecessarily mark outputs as sensitive
- **Terraform Best Practices**: Aligns with proper handling of sensitivity in Terraform

## Testing

- ✅ Pre-commit checks passed
- ✅ Terraform validation passed  
- ✅ Linting checks passed

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix that would cause existing functionality to not work as expected)

Fixes #683

---

*This PR was composed by GitHub Copilot agent as part of automated issue resolution.*