### PR TITLE
Add custom_ca_trust_certificates_base64 list property

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@ resource "azurerm_kubernetes_cluster" "main" {
   automatic_upgrade_channel           = var.automatic_channel_upgrade
   azure_policy_enabled                = var.azure_policy_enabled
   cost_analysis_enabled               = var.cost_analysis_enabled
+  custom_ca_trust_certificates_base64 = var.custom_ca_trust_certificates_base64
   disk_encryption_set_id              = var.disk_encryption_set_id
   dns_prefix                          = var.prefix
   dns_prefix_private_cluster          = var.dns_prefix_private_cluster

--- a/variables.tf
+++ b/variables.tf
@@ -457,6 +457,13 @@ variable "create_role_assignments_for_application_gateway" {
   nullable    = false
 }
 
+variable "custom_ca_trust_certificates_base64" {
+  type        = list(any)
+  default     = []
+  description = "(Optional) A list of up to 10 base64 encoded CA certificates that will be added to the trust store on nodes."
+  nullable    = false
+}
+
 variable "data_collection_settings" {
   type = object({
     data_collection_interval                     = string


### PR DESCRIPTION
## Describe your changes

This just adds in the custom_ca_trust_certificates_base64 property to the azurerm_kubernetes_cluster with a default of an empty array.
Up to 10 base64 encoded strings can be added in the array representing certificates AKS nodes can trust.

## Issue number

#356
#379

## Checklist before requesting a review
- [X] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [X] I have executed pre-commit on my machine
- [X] I have passed pr-check on my machine

Thanks for your cooperation!

