### PR TITLE
feat: add node_provisioning_profile support

### DIFF
--- a/examples/startup/main.tf
+++ b/examples/startup/main.tf
@@ -111,6 +111,10 @@ module "aks" {
   vnet_subnet = {
     id = azurerm_subnet.test.id
   }
+  node_provisioning_profile = {
+    mode               = "Auto"
+    default_node_pools = "Auto"
+  }
 
   agents_labels = {
     "node1" : "label1"

--- a/main.tf
+++ b/main.tf
@@ -517,6 +517,14 @@ resource "azurerm_kubernetes_cluster" "main" {
       internal_ingress_gateway_enabled = var.service_mesh_profile.internal_ingress_gateway_enabled
     }
   }
+  dynamic "node_provisioning_profile" {
+    for_each = var.node_provisioning_profile == null ? [] : [var.node_provisioning_profile]
+
+    content {
+      mode               = node_provisioning_profile.value.mode
+      default_node_pools = node_provisioning_profile.value.default_node_pools
+    }
+  }
   dynamic "service_principal" {
     for_each = var.client_id != "" && var.client_secret != "" ? ["service_principal"] : []
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -182,6 +182,16 @@ output "network_profile" {
   value       = azurerm_kubernetes_cluster.main.network_profile
 }
 
+output "node_provisioning_profile" {
+  description = "The `azurerm_kubernetes_cluster`'s `node_provisioning_profile` block."
+  value       = try(azurerm_kubernetes_cluster.main.node_provisioning_profile[0], null)
+}
+
+output "node_provisioning_profile_enabled" {
+  description = "Has the `azurerm_kubernetes_cluster` turned on `node_provisioning_profile` block?"
+  value       = can(azurerm_kubernetes_cluster.main.node_provisioning_profile[0])
+}
+
 output "node_resource_group" {
   description = "The auto-generated Resource Group which contains the resources for this Managed Kubernetes Cluster."
   value       = azurerm_kubernetes_cluster.main.node_resource_group

--- a/variables.tf
+++ b/variables.tf
@@ -1043,6 +1043,45 @@ variable "node_network_profile" {
 EOT
 }
 
+variable "node_provisioning_profile" {
+  type = object({
+    mode               = optional(string)
+    default_node_pools = optional(string)
+  })
+  default     = null
+  description = <<-EOT
+    (Optional) A `node_provisioning_profile` block that controls node provisioning behavior for the cluster.
+
+    object({
+      mode               = (Optional) Specifies the provisioning mode for node pools created in this cluster. Possible values are `Auto` and `Manual`. Defaults to `Manual`.
+      default_node_pools = (Optional) Specifies whether default node pools should be provisioned automatically. Possible values are `Auto` and `None`. Defaults to `Auto`.
+    })
+
+    Note: At least one of `mode` or `default_node_pools` must be specified when this block is configured.
+EOT
+
+  validation {
+    condition = var.node_provisioning_profile == null ? true : (
+      var.node_provisioning_profile.mode != null || var.node_provisioning_profile.default_node_pools != null
+    )
+    error_message = "When `node_provisioning_profile` is configured, at least one of `mode` or `default_node_pools` must be specified."
+  }
+
+  validation {
+    condition = var.node_provisioning_profile == null ? true : (
+      var.node_provisioning_profile.mode == null || contains(["Auto", "Manual"], var.node_provisioning_profile.mode)
+    )
+    error_message = "`mode` must be either `Auto` or `Manual`."
+  }
+
+  validation {
+    condition = var.node_provisioning_profile == null ? true : (
+      var.node_provisioning_profile.default_node_pools == null || contains(["Auto", "None"], var.node_provisioning_profile.default_node_pools)
+    )
+    error_message = "`default_node_pools` must be either `Auto` or `None`."
+  }
+}
+
 variable "node_os_channel_upgrade" {
   type        = string
   default     = null


### PR DESCRIPTION
## Describe your changes

This PR adds support for the `node_provisioning_profile` block to the `azurerm_kubernetes_cluster` resource, enabling control of node provisioning behavior at the cluster level.

### Changes Made:
- **variables.tf**: Added `node_provisioning_profile` variable with three validation blocks:
  - Ensures at least one field (`mode` or `default_node_pools`) is specified when block is configured
  - Validates `mode` values (Auto/Manual)
  - Validates `default_node_pools` values (Auto/None)
- **main.tf**: Added dynamic `node_provisioning_profile` block to the `azurerm_kubernetes_cluster` resource
- **outputs.tf**: Added two outputs:
  - `node_provisioning_profile` - Returns the block content
  - `node_provisioning_profile_enabled` - Returns boolean indicating if enabled
- **examples/startup/main.tf**: Updated to demonstrate usage with both fields set to "Auto"

### Feature Details:
The `node_provisioning_profile` block supports two optional parameters:
- `mode`: Provisioning mode for node pools (Auto/Manual, defaults to Manual)
- `default_node_pools`: Whether default node pools auto-provision (Auto/None, defaults to Auto)

The implementation follows existing module patterns for optional blocks and includes proper validation at plan time.

## Issue number

#720

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine