### PR TITLE
fix: accept private_dns_zone_id from the Bleu national partner cloud

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -68,9 +68,9 @@ locals {
   use_brown_field_gw_for_ingress = var.brown_field_application_gateway_for_ingress != null
   use_green_field_gw_for_ingress = var.green_field_application_gateway_for_ingress != null
   valid_private_dns_zone_regexs = [
-    "private\\.[a-z0-9]+\\.[a-z0-9.\\-]+",
-    "privatelink\\.[a-z0-9]+\\.[a-z0-9.\\-]+",
-    "[a-zA-Z0-9\\-]{1,32}\\.private\\.[a-z0-9]+\\.[a-z0-9.\\-]+",
-    "[a-zA-Z0-9\\-]{1,32}\\.privatelink\\.[a-z0-9]+\\.[a-z0-9.\\-]+",
+    "private\\.[a-z0-9]+\\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+",
+    "privatelink\\.[a-z0-9]+\\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+",
+    "[a-zA-Z0-9\\-]{1,32}\\.private\\.[a-z0-9]+\\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+",
+    "[a-zA-Z0-9\\-]{1,32}\\.privatelink\\.[a-z0-9]+\\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+",
   ]
 }

--- a/locals.tf
+++ b/locals.tf
@@ -68,9 +68,9 @@ locals {
   use_brown_field_gw_for_ingress = var.brown_field_application_gateway_for_ingress != null
   use_green_field_gw_for_ingress = var.green_field_application_gateway_for_ingress != null
   valid_private_dns_zone_regexs = [
-    "private\\.[a-z0-9]+\\.azmk8s\\.io",
-    "privatelink\\.[a-z0-9]+\\.azmk8s\\.io",
-    "[a-zA-Z0-9\\-]{1,32}\\.private\\.[a-z0-9]+\\.azmk8s\\.io",
-    "[a-zA-Z0-9\\-]{1,32}\\.privatelink\\.[a-z0-9]+\\.azmk8s\\.io",
+    "private\\.[a-z0-9]+\\.[a-z0-9.\\-]+",
+    "privatelink\\.[a-z0-9]+\\.[a-z0-9.\\-]+",
+    "[a-zA-Z0-9\\-]{1,32}\\.private\\.[a-z0-9]+\\.[a-z0-9.\\-]+",
+    "[a-zA-Z0-9\\-]{1,32}\\.privatelink\\.[a-z0-9]+\\.[a-z0-9.\\-]+",
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -730,7 +730,7 @@ resource "azurerm_kubernetes_cluster" "main" {
     }
     precondition {
       condition     = (var.private_dns_zone_id == null || var.private_dns_zone_id == "None" || var.private_dns_zone_id == "System") ? true : (anytrue([for r in local.valid_private_dns_zone_regexs : try(regex(r, local.private_dns_zone_name) == local.private_dns_zone_name, false)]))
-      error_message = "The private_dns_zone_id must be either null, \"None\", \"System\", or a valid private DNS zone resource ID. Valid DNS zone formats are: `privatelink.<region>.azmk8s.io`, `<subzone>.privatelink.<region>.azmk8s.io`, `private.<region>.azmk8s.io`, `<subzone>.private.<region>.azmk8s.io`"
+      error_message = "The private_dns_zone_id must be either null, \"None\", \"System\", or a valid private DNS zone resource ID. Valid DNS zone formats are: `private.<region>.<cloud-suffix>`, `privatelink.<region>.<cloud-suffix>`, `<subzone>.private.<region>.<cloud-suffix>`, or `<subzone>.privatelink.<region>.<cloud-suffix>`. Azure validates the exact cloud-specific suffix server-side."
     }
   }
 }


### PR DESCRIPTION
## fix: accept private_dns_zone_id from Bleu national partner cloud (with stricter DNS validation)

This PR merges the changes from PR #748 (by @benmille) and improves the DNS suffix validation pattern to be more precise while remaining cloud-agnostic.

### Background

PR #748 / Issue #747: The `private_dns_zone_id` precondition in `locals.tf` hardcoded `azmk8s.io`, rejecting valid AKS DNS zones on the [Bleu national partner cloud](https://learn.microsoft.com/en-us/azure/azure-sovereign-clouds/partner/overview-national-partner-clouds) which uses `cx.prod-aks.sovcloud-api.fr`.

### Changes

**`locals.tf`** — 4 regex patterns updated:

The original PR #748 replaced `azmk8s\\.io` with `[a-z0-9.\\-]+`. This release branch further refines the suffix to use RFC 952/1123 DNS label validation:

```diff
- "private\\.[a-z0-9]+\\.[a-z0-9.\\-]+",
+ "private\\.[a-z0-9]+\\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+",
```

Pattern B (`[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+`) enforces:
- Each DNS label starts and ends with alphanumeric characters
- Labels are separated by single dots
- At least two labels in the suffix

**`main.tf`** — error message updated (from PR #748, unchanged):
- Replaced hardcoded `azmk8s.io` references with generic `<cloud-suffix>` placeholders

### Why Pattern B over Pattern A?

Pattern A (`[a-z0-9.\\-]+`) incorrectly accepts 8 types of invalid DNS names that Pattern B correctly rejects:

| Invalid Zone | Pattern A | Pattern B | Issue |
|---|---|---|---|
| `privatelink.eastus.azmk8s.io.` | ❌ Accepts | ✅ Rejects | Trailing dot |
| `private.eastus.trailing.` | ❌ Accepts | ✅ Rejects | Trailing dot |
| `privatelink.eastus.azmk8s..io` | ❌ Accepts | ✅ Rejects | Consecutive dots |
| `private.eastus.double..dot` | ❌ Accepts | ✅ Rejects | Consecutive dots |
| `privatelink.eastus..` | ❌ Accepts | ✅ Rejects | Dot ending |
| `privatelink.eastus.-leading.hyphen` | ❌ Accepts | ✅ Rejects | Leading hyphen in label |
| `privatelink.eastus.trailing-.hyphen` | ❌ Accepts | ✅ Rejects | Trailing hyphen in label |
| `privatelink.eastus.-.foo` | ❌ Accepts | ✅ Rejects | Hyphen-only label |

Both patterns correctly accept all 16 tested valid zones (public cloud, Bleu cloud, China cloud, subzone variants, hypothetical future clouds).

### Test Results (from Trello analysis)

**Valid zones (all accepted by both patterns):**
- `privatelink.eastus.azmk8s.io` ✅
- `private.eastus.azmk8s.io` ✅
- `sub.privatelink.eastus.azmk8s.io` ✅
- `privatelink.bleufrancecentral.cx.prod-aks.sovcloud-api.fr` ✅
- `privatelink.chinaeast2.cx.prod.service.azk8s.cn` ✅
- `privatelink.region1.sovereign.cloud.example.com` ✅
- And 10 more variants

**Invalid zones (correctly rejected by Pattern B):**
- `random.garbage` ❌
- `notprivate.eastus.azmk8s.io` ❌
- All 8 edge cases listed above ❌

### Non-breaking

Existing users with `azmk8s.io` zones are unaffected — the new pattern is a superset of the old hardcoded pattern.

Fixes #747