### PR TITLE
Fix null value check for undrainable_node_behavior

### DIFF
--- a/extra_node_pool.tf
+++ b/extra_node_pool.tf
@@ -180,7 +180,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "node_pool_create_before_destroy
       error_message = "Exactly one of `max_surge` or `max_unavailable` must be specified in `upgrade_settings` for node pool '${each.value.name}'."
     }
     precondition {
-      condition     = each.value.upgrade_settings == null || try(each.value.upgrade_settings.undrainable_node_behavior, null) == null || contains(["Cordon", "Schedule"], try(each.value.upgrade_settings.undrainable_node_behavior, ""))
+      condition     = each.value.upgrade_settings == null || try(each.value.upgrade_settings.undrainable_node_behavior, null) == null ? true : contains(["Cordon", "Schedule"], each.value.upgrade_settings.undrainable_node_behavior)
       error_message = "`undrainable_node_behavior` in `upgrade_settings` must be `null`, `\"Cordon\"`, or `\"Schedule\"` for node pool '${each.value.name}'."
     }
   }


### PR DESCRIPTION
## Describe your changes

PR #733 introduced a precondition to check for the value of `undrainable_node_behavior` however it fails when the value is `null`. This happens because Terraform does not short-circuit evaluate `||` and calls `contains` with `null`, which results in an error.

This switches that check to use a ternary operator to check for `null`, which will short-circuit before calling `contains`.

## Issue number

Closes #760 

## Checklist before requesting a review
- [X] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [X] I have executed pre-commit on my machine
- [X] I have passed pr-check on my machine

Thanks for your cooperation!

