### PR TITLE
fix: Handle null undrainable_node_behavior in precondition validation

### DIFF
--- a/extra_node_pool.tf
+++ b/extra_node_pool.tf
@@ -180,7 +180,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "node_pool_create_before_destroy
       error_message = "Exactly one of `max_surge` or `max_unavailable` must be specified in `upgrade_settings` for node pool '${each.value.name}'."
     }
     precondition {
-      condition     = each.value.upgrade_settings == null || try(each.value.upgrade_settings.undrainable_node_behavior, null) == null || contains(["Cordon", "Schedule"], try(each.value.upgrade_settings.undrainable_node_behavior, ""))
+      condition     = each.value.upgrade_settings == null || try(each.value.upgrade_settings.undrainable_node_behavior, null) == null || try(contains(["Cordon", "Schedule"], each.value.upgrade_settings.undrainable_node_behavior), false)
       error_message = "`undrainable_node_behavior` in `upgrade_settings` must be `null`, `\"Cordon\"`, or `\"Schedule\"` for node pool '${each.value.name}'."
     }
   }
@@ -347,7 +347,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "node_pool_create_after_destroy"
       error_message = "Exactly one of `max_surge` or `max_unavailable` must be specified in `upgrade_settings` for node pool '${each.value.name}'."
     }
     precondition {
-      condition     = each.value.upgrade_settings == null || try(each.value.upgrade_settings.undrainable_node_behavior, null) == null || contains(["Cordon", "Schedule"], try(each.value.upgrade_settings.undrainable_node_behavior, ""))
+      condition     = each.value.upgrade_settings == null || try(each.value.upgrade_settings.undrainable_node_behavior, null) == null || try(contains(["Cordon", "Schedule"], each.value.upgrade_settings.undrainable_node_behavior), false)
       error_message = "`undrainable_node_behavior` in `upgrade_settings` must be `null`, `\"Cordon\"`, or `\"Schedule\"` for node pool '${each.value.name}'."
     }
   }


### PR DESCRIPTION
Fixes #760

## Description

When `upgrade_settings.undrainable_node_behavior` is explicitly set to `null`, the `contains()` function in the precondition validation fails with:

```
Error: Invalid function argument
│ Invalid value for "value" parameter: argument must not be null.
```

This happens because `try(each.value.upgrade_settings.undrainable_node_behavior, "")` succeeds (the attribute exists, it's just null), so `contains()` receives null instead of a string.

## Fix

Wrap the entire `contains()` call in `try(..., false)` so that if the value is null, the function call fails gracefully and the precondition evaluates to `false` — but since the middle condition (`== null`) already short-circuits, this branch is only reached for non-null values.

## Testing

Validated that:
- `undrainable_node_behavior = null` → no error (short-circuits at middle condition)
- `undrainable_node_behavior = "Cordon"` → passes validation
- `undrainable_node_behavior = "invalid"` → fails with proper error message